### PR TITLE
Add indexed map functions

### DIFF
--- a/dartx/lib/src/iterable.dart
+++ b/dartx/lib/src/iterable.dart
@@ -571,6 +571,29 @@ extension IterableX<E> on Iterable<E> {
     }
   }
 
+  /// Returns a new lazy [Iterable] containing the results of applying the
+  /// given [transform] function to each element and its index in the original
+  /// collection.
+  Iterable<R> mapIndexed<R>(R Function(int index, E) transform) sync* {
+    var index = 0;
+    for (var element in this) {
+      yield transform(index++, element);
+    }
+  }
+
+  /// Returns a new lazy [Iterable] containing only the non-null results of
+  /// applying the given [transform] function to each element and its index
+  /// in the original collection.
+  Iterable<R> mapIndexedNotNull<R>(R Function(int index, E) transform) sync* {
+    var index = 0;
+    for (var element in this) {
+      final result = transform(index++, element);
+      if (result != null) {
+        yield result;
+      }
+    }
+  }
+
   /// Returns a new lazy [Iterable] which performs the given action on each
   /// element.
   Iterable<E> onEach(void action(E element)) sync* {

--- a/dartx/test/iterable_test.dart
+++ b/dartx/test/iterable_test.dart
@@ -408,6 +408,27 @@ void main() {
           [1, 2, 3, 4].mapNotNull((it) => it % 2 == 0 ? it * 2 : null), [4, 8]);
     });
 
+    test('.mapIndexed()', () {
+      expect([].mapIndexed((index, it) => 1), []);
+      expect([1, 2, 3, 4].mapIndexed((index, it) => null),
+          [null, null, null, null]);
+      expect([5, 4, null, 2].mapIndexed((index, it) => index), [0, 1, 2, 3]);
+      expect(
+          [1, 2, 3, 4].mapIndexed((index, it) => it % 2 == 0 ? it * 2 : null),
+          [null, 4, null, 8]);
+    });
+
+    test('.mapIndexedNotNull()', () {
+      expect([].mapIndexedNotNull((index, it) => 1), []);
+      expect([1, 2, 3, 4].mapIndexedNotNull((index, it) => null), []);
+      expect([5, 4, null, 2].mapIndexedNotNull((index, it) => index),
+          [0, 1, 2, 3]);
+      expect(
+          [1, 2, 3, 4]
+              .mapIndexedNotNull((index, it) => it % 2 == 0 ? it * 2 : null),
+          [4, 8]);
+    });
+
     test('.onEach()', () {
       expect([].onEach((it) => 1), []);
       expect(


### PR DESCRIPTION
Sometimes when mapping iterables, the index is important.

```dart
final mapped = ["a", "b", "c"].mapIndexed((index, it) => "$index => '$it'"));
print(mapped); // [0 => 'a', 1 => 'b', 2 => 'c']
```