### PR TITLE
Add Iterable.filter* methods

### DIFF
--- a/dartx/lib/src/iterable.dart
+++ b/dartx/lib/src/iterable.dart
@@ -483,6 +483,45 @@ extension IterableX<E> on Iterable<E> {
     return list;
   }
 
+  /// Returns all elements matching the given [predicate].
+  Iterable<E> filter(bool predicate(E element)) => where(predicate);
+
+  /// Returns all elements that satisfy the given [predicate].
+  Iterable<E> filterIndexed(bool predicate(E element, int index)) =>
+      whereIndexed(predicate);
+
+  /// Appends all elements matching the given [predicate] to the given
+  /// [destination].
+  void filterTo(List<E> destination, bool predicate(E element)) =>
+      whereTo(destination, predicate);
+
+  /// Appends all elements matching the given [predicate] to the given
+  /// [destination].
+  void filterIndexedTo(
+          List<E> destination, bool predicate(E element, int index)) =>
+      whereIndexedTo(destination, predicate);
+
+  /// Returns all elements not matching the given [predicate].
+  Iterable<E> filterNot(bool predicate(E element)) => whereNot(predicate);
+
+  /// Returns all elements not matching the given [predicate].
+  Iterable<E> filterNotIndexed(bool predicate(E element, int index)) =>
+      whereNotIndexed(predicate);
+
+  /// Appends all elements not matching the given [predicate] to the given
+  /// [destination].
+  void filterNotTo(List<E> destination, bool predicate(E element)) =>
+      whereNotTo(destination, predicate);
+
+  /// Appends all elements not matching the given [predicate] to the given
+  /// [destination].
+  void filterNotToIndexed(
+          List<E> destination, bool predicate(E element, int index)) =>
+      whereNotToIndexed(destination, predicate);
+
+  /// Returns a new lazy [Iterable] with all elements which are not null.
+  Iterable<E> filterNotNull() => where((element) => element != null);
+
   /// Returns all elements that satisfy the given [predicate].
   Iterable<E> whereIndexed(bool predicate(E element, int index)) sync* {
     var index = 0;

--- a/dartx/test/iterable_test.dart
+++ b/dartx/test/iterable_test.dart
@@ -339,6 +339,73 @@ void main() {
       expect([1, 2, 3].lastWhile((e) => true), [1, 2, 3]);
     });
 
+    test('.filterIndexed()', () {
+      var result = [6, 5, 4, 3, 2, 1, 0].filter((it) => it % 2 == 0);
+      expect(result, [6, 4, 2, 0]);
+    });
+
+    test('.filterIndexed()', () {
+      var index = 0;
+      var result = [6, 5, 4, 3, 2, 1, 0].filterIndexed((it, i) {
+        expect(it, 6 - index);
+        expect(i, index);
+        index++;
+        return i > 3;
+      });
+      expect(result, [2, 1, 0]);
+    });
+
+    test('.filterTo()', () {
+      var list = <int>[];
+      [1, 2, 3, 4, 3, 2, 1].filterTo(list, (e) => e % 2 == 0);
+      expect(list, [2, 4, 2]);
+    });
+
+    test('.filterToIndexed()', () {
+      var index = 0;
+      var list = <int>[];
+      [1, 2, 3, 4, 3, 2, 1].filterIndexedTo(list, (e, i) {
+        expect(index++, i);
+        return e % 2 == 0;
+      });
+      expect(list, [2, 4, 2]);
+    });
+
+    test('.filterNot()', () {
+      expect([1, 2, 3, 4, 3, 2, 1].filterNot((e) => e % 2 == 0), [1, 3, 3, 1]);
+    });
+
+    test('.filterNotIndexed()', () {
+      var index = 0;
+      expect(
+        [1, 2, 3, 4, 3, 2, 1].filterNotIndexed((e, i) {
+          expect(index++, i);
+          return e % 2 == 0;
+        }),
+        [1, 3, 3, 1],
+      );
+    });
+
+    test('.filterNotTo()', () {
+      var list = <int>[];
+      [1, 2, 3, 4, 3, 2, 1].filterNotTo(list, (e) => e % 2 == 0);
+      expect(list, [1, 3, 3, 1]);
+    });
+
+    test('.filterToIndexed()', () {
+      var index = 0;
+      var list = <int>[];
+      [1, 2, 3, 4, 3, 2, 1].filterNotToIndexed(list, (e, i) {
+        expect(index++, i);
+        return e % 2 == 0;
+      });
+      expect(list, [1, 3, 3, 1]);
+    });
+
+    test('.filterNotNull()', () {
+      expect([0, null, 1, null, null, 2].filterNotNull(), [0, 1, 2]);
+    });
+
     test('.whereIndexed()', () {
       var index = 0;
       var result = [6, 5, 4, 3, 2, 1, 0].whereIndexed((it, i) {


### PR DESCRIPTION
`filter*` allows filtering values in iterables. (Alternative to the already existing `where*` functions).

### Justification

In most languages it's called `filter`, except for dart where it's oddly called `where`. 
`filter`, together with `map` and `flatMap` are the most common used operations on Iterables. While `map` is part of the official `dart` SDK, `flatMap` was already added to `dartx`. The new `filter*` methods follow the same logic.

This makes it much easier for newcomers of Dart to work with Iterables.

 

