### PR TITLE
Adding time extensions

### DIFF
--- a/dartx/README.md
+++ b/dartx/README.md
@@ -92,6 +92,43 @@ var number = '12345'.toIntOrNull(); // 12345
 var notANumber = '123-45'.toIntOrNull(); // null
 ```
 
+## Time 
+Credits to [joboms](https://github.com/jogboms)!
+```dart
+final Duration tenMinutes = 10.minutes;
+final DateTime afterTenMinutes = DateTime.now() + 10.minutes;
+final Duration tenMinutesAndSome = 10.minutes + 15.seconds;
+final int tenMinutesInSeconds = 10.minutes.inSeconds;
+final DateTime tenMinutesLater = 10.minutes.later;
+```
+
+You can perform all basic arithmetic operations on `Duration` as you always have been:
+
+```dart
+final Duration interval = 10.minutes + 15.seconds - 3.minutes + 2.hours;
+final Duration doubled = interval * 2;
+```
+
+You can also use these operations on `DateTime`:
+
+```dart
+final DateTime oneHourAfter = DateTime() + 1.hours;
+```
+
+`Duration` is easily convertible as it always has been:
+
+```dart
+final int twoMinutesInSeconds = 2.minutes.inSeconds;
+```
+
+You can also convert `Duration` to `DateTime`, if needed:
+
+```dart
+final DateTime timeInFuture = 5.minutes.later;
+final DateTime timeInPast = 5.minutes.ago;
+```
+
+
 ## Function
 
 ### invoke()

--- a/dartx/lib/dartx.dart
+++ b/dartx/lib/dartx.dart
@@ -18,3 +18,4 @@ part 'src/list.dart';
 part 'src/num.dart';
 part 'src/sorted_list.dart';
 part 'src/string.dart';
+part 'src/time.dart';

--- a/dartx/lib/src/num.dart
+++ b/dartx/lib/src/num.dart
@@ -56,6 +56,16 @@ extension NumX<T extends num> on T {
     }
   }
 
+  /// Returns a [Duration] equal to this [int] number of weeks.
+  Duration get weeks {
+    if (this is int) {
+      return Duration(days: (this as int) * 7);
+    } else {
+      var microseconds = this * Duration.microsecondsPerDay;
+      return Duration(microseconds: microseconds.toInt() * 7);
+    }
+  }
+
   /// Ensures that this value lies in the specified range
   /// [minimumValue]..[maximumValue].
   ///

--- a/dartx/lib/src/time.dart
+++ b/dartx/lib/src/time.dart
@@ -1,0 +1,46 @@
+part of dartx;
+
+extension TimeIntX on int {
+  /// Returns a Duration represented in weeks
+  Duration get weeks => Duration(days: this * 7);
+
+  /// Returns a Duration represented in days
+  Duration get days => Duration(days: this);
+
+  /// Returns a Duration represented in hours
+  Duration get hours => Duration(hours: this);
+
+  /// Returns a Duration represented in minutes
+  Duration get minutes => Duration(minutes: this);
+
+  /// Returns a Duration represented in seconds
+  Duration get seconds => Duration(seconds: this);
+
+  /// Returns a Duration represented in milliseconds
+  Duration get milliseconds => Duration(milliseconds: this);
+
+  /// Returns a Duration represented in microseconds
+  Duration get microseconds => Duration(microseconds: this);
+
+  /// Returns a Duration represented in nanoseconds
+  Duration get nanoseconds => Duration(microseconds: this ~/ 1000);
+}
+
+extension DateTimeX on DateTime {
+  /// Adds this DateTime and Duration and returns the sum as a new DateTime object.
+  DateTime operator +(Duration duration) => add(duration);
+
+  /// Subtracts the Duration from this DateTime returns the difference as a new DateTime object.
+  DateTime operator -(Duration duration) => subtract(duration);
+}
+
+extension DurationX on Duration {
+  /// Returns the representation in weeks
+  int get inWeeks => (inDays / 7).ceil();
+
+  /// Adds the Duration to the current DateTime and returns a DateTime in the future
+  DateTime get later => DateTime.now() + this;
+
+  /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
+  DateTime get ago => DateTime.now() - this;
+}

--- a/dartx/lib/src/time.dart
+++ b/dartx/lib/src/time.dart
@@ -1,36 +1,12 @@
 part of dartx;
 
-extension TimeIntX on int {
-  /// Returns a Duration represented in weeks
-  Duration get weeks => Duration(days: this * 7);
-
-  /// Returns a Duration represented in days
-  Duration get days => Duration(days: this);
-
-  /// Returns a Duration represented in hours
-  Duration get hours => Duration(hours: this);
-
-  /// Returns a Duration represented in minutes
-  Duration get minutes => Duration(minutes: this);
-
-  /// Returns a Duration represented in seconds
-  Duration get seconds => Duration(seconds: this);
-
-  /// Returns a Duration represented in milliseconds
-  Duration get milliseconds => Duration(milliseconds: this);
-
-  /// Returns a Duration represented in microseconds
-  Duration get microseconds => Duration(microseconds: this);
-
-  /// Returns a Duration represented in nanoseconds
-  Duration get nanoseconds => Duration(microseconds: this ~/ 1000);
-}
-
 extension DateTimeX on DateTime {
-  /// Adds this DateTime and Duration and returns the sum as a new DateTime object.
+  /// Adds this DateTime and Duration and returns the sum as a new DateTime
+  /// object.
   DateTime operator +(Duration duration) => add(duration);
 
-  /// Subtracts the Duration from this DateTime returns the difference as a new DateTime object.
+  /// Subtracts the Duration from this DateTime returns the difference as a new
+  /// DateTime object.
   DateTime operator -(Duration duration) => subtract(duration);
 }
 
@@ -38,9 +14,11 @@ extension DurationX on Duration {
   /// Returns the representation in weeks
   int get inWeeks => (inDays / 7).ceil();
 
-  /// Adds the Duration to the current DateTime and returns a DateTime in the future
+  /// Adds the Duration to the current DateTime and returns a DateTime in the
+  /// future
   DateTime get later => DateTime.now() + this;
 
-  /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
+  /// Subtracts the Duration from the current DateTime and returns a DateTime
+  /// in the past
   DateTime get ago => DateTime.now() - this;
 }

--- a/dartx/pubspec.yaml
+++ b/dartx/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartx
 description: Superpowers for Dart. Collection of useful static extension methods.
-version: 0.1.2
+version: 0.2.0
 author: Simon Leier <simonleier@gmail.com>
 homepage: https://github.com/leisim/dartx
 

--- a/dartx/test/time_test.dart
+++ b/dartx/test/time_test.dart
@@ -1,0 +1,76 @@
+import 'package:test/test.dart';
+import 'package:dartx/dartx.dart';
+
+void main() {
+  group('TimeExtension', () {
+    group('Integers', () {
+      test('can be converted into weeks', () {
+        expect(1.weeks, Duration(days: 7));
+      });
+
+      test('can be converted into days', () {
+        expect(5.days, Duration(days: 5));
+      });
+
+      test('can be converted into hours', () {
+        expect(22.hours, Duration(hours: 22));
+      });
+
+      test('can be converted into minutes', () {
+        expect(45.minutes, Duration(minutes: 45));
+      });
+
+      test('can be converted into seconds', () {
+        expect(30.seconds, Duration(seconds: 30));
+      });
+
+      test('can be converted into milliseconds', () {
+        expect(15.milliseconds, Duration(milliseconds: 15));
+      });
+
+      test('can be converted into microseconds', () {
+        expect(10.microseconds, Duration(microseconds: 10));
+      });
+
+      test('can be converted into nanoseconds', () {
+        expect(5.nanoseconds, Duration(microseconds: 5 ~/ 1000));
+      });
+    });
+
+    group('DateTime', () {
+      test('can subtract Durations', () {
+        expect(
+          DateTime(2019, 1, 1, 0, 0, 30) - 30.seconds,
+          DateTime(2019, 1, 1, 0, 0, 0),
+          );
+      });
+
+      test('can add Durations', () {
+        expect(
+          DateTime(2019, 1, 1, 0, 0, 30) - 30.seconds,
+          DateTime(2019, 1, 1, 0, 0, 0),
+          );
+      });
+    });
+
+    group('Duration', () {
+      test('can be converted to weeks', () {
+        expect(7.days.inWeeks, 1);
+      });
+
+      test('can be converted into a later DateTime', () {
+        expect(7.days.later, _isAbout(DateTime.now() + 7.days));
+      });
+
+      test('can be converted into a previous DateTime', () {
+        expect(7.days.ago, _isAbout(DateTime.now() - 7.days));
+      });
+    });
+  });
+}
+
+// Checks if the two times returned a *just* about equal. Since `later` and
+// `ago` use DateTime.now(), we can't create an expected condition that is
+// exactly equal.
+Matcher _isAbout(DateTime expected) => predicate<DateTime>((dateTime) =>
+dateTime.millisecondsSinceEpoch - expected.millisecondsSinceEpoch < 1);

--- a/dartx/test/time_test.dart
+++ b/dartx/test/time_test.dart
@@ -32,9 +32,6 @@ void main() {
         expect(10.microseconds, Duration(microseconds: 10));
       });
 
-      test('can be converted into nanoseconds', () {
-        expect(5.nanoseconds, Duration(microseconds: 5 ~/ 1000));
-      });
     });
 
     group('DateTime', () {


### PR DESCRIPTION
Hello!

I got the code produced by jogboms on https://github.com/jogboms/time.dart and merged his great libraries into dartx.

This commit introduces all the jogbom's extensions to time types, like producing durations through integers and some other utility methods.