### PR TITLE
Remove quiver dependency

### DIFF
--- a/lib/dartx.dart
+++ b/lib/dartx.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 import 'package:characters/characters.dart';
 import 'package:collection/collection.dart' hide DelegatingList;
 import 'package:crypto/crypto.dart' as crypto;
-import 'package:quiver/collection.dart';
 
 export 'package:time/time.dart';
 

--- a/lib/src/sorted_list.dart
+++ b/lib/src/sorted_list.dart
@@ -6,7 +6,7 @@ Comparator<E> _getComparator<E>(int order, Comparable selector(E element)) {
   };
 }
 
-class _SortedList<E> extends DelegatingList<E> {
+class _SortedList<E> extends _DelegatingList<E> {
   final Iterable<E> _source;
   final Comparator<E> _comparator;
   final Comparator<E> _parentComparator;
@@ -73,5 +73,260 @@ class _SortedList<E> extends DelegatingList<E> {
     } else {
       return compare;
     }
+  }
+}
+
+/// An implementation of [List] that delegates all methods to another [List].
+///
+/// Copied from quiver
+///
+/// For instance you can create a FruitList like this :
+///
+///     class FruitList extends DelegatingList<Fruit> {
+///       final List<Fruit> _fruits = [];
+///
+///       List<Fruit> get delegate => _fruits;
+///
+///       // custom methods
+///     }
+abstract class _DelegatingList<E> extends _DelegatingIterable<E>
+    implements List<E> {
+  @override
+  List<E> get delegate;
+
+  @override
+  E operator [](int index) => delegate[index];
+
+  @override
+  void operator []=(int index, E value) {
+    delegate[index] = value;
+  }
+
+  @override
+  List<E> operator +(List<E> other) => delegate + other;
+
+  @override
+  void add(E value) => delegate.add(value);
+
+  @override
+  void addAll(Iterable<E> iterable) => delegate.addAll(iterable);
+
+  @override
+  Map<int, E> asMap() => delegate.asMap();
+
+  @override
+  _DelegatingList<T> cast<T>() {
+    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
+    throw UnimplementedError('cast');
+  }
+
+  @override
+  void clear() => delegate.clear();
+
+  @override
+  void fillRange(int start, int end, [E fillValue]) =>
+      delegate.fillRange(start, end, fillValue);
+
+  @override
+  set first(E element) {
+    if (isEmpty) throw RangeError.index(0, this);
+    this[0] = element;
+  }
+
+  @override
+  Iterable<E> getRange(int start, int end) => delegate.getRange(start, end);
+
+  @override
+  int indexOf(E element, [int start = 0]) => delegate.indexOf(element, start);
+
+  @override
+  int indexWhere(bool test(E element), [int start = 0]) =>
+      delegate.indexWhere(test, start);
+
+  @override
+  void insert(int index, E element) => delegate.insert(index, element);
+
+  @override
+  void insertAll(int index, Iterable<E> iterable) =>
+      delegate.insertAll(index, iterable);
+
+  @override
+  set last(E element) {
+    if (isEmpty) throw RangeError.index(0, this);
+    this[length - 1] = element;
+  }
+
+  @override
+  int lastIndexOf(E element, [int start]) =>
+      delegate.lastIndexOf(element, start);
+
+  @override
+  int lastIndexWhere(bool test(E element), [int start]) =>
+      delegate.lastIndexWhere(test, start);
+
+  @override
+  set length(int newLength) {
+    delegate.length = newLength;
+  }
+
+  @override
+  bool remove(Object value) => delegate.remove(value);
+
+  @override
+  E removeAt(int index) => delegate.removeAt(index);
+
+  @override
+  E removeLast() => delegate.removeLast();
+
+  @override
+  void removeRange(int start, int end) => delegate.removeRange(start, end);
+
+  @override
+  void removeWhere(bool test(E element)) => delegate.removeWhere(test);
+
+  @override
+  void replaceRange(int start, int end, Iterable<E> iterable) =>
+      delegate.replaceRange(start, end, iterable);
+
+  @override
+  void retainWhere(bool test(E element)) => delegate.retainWhere(test);
+
+  @override
+  Iterable<E> get reversed => delegate.reversed;
+
+  @override
+  void setAll(int index, Iterable<E> iterable) =>
+      delegate.setAll(index, iterable);
+
+  @override
+  void setRange(int start, int end, Iterable<E> iterable,
+          [int skipCount = 0]) =>
+      delegate.setRange(start, end, iterable, skipCount);
+
+  @override
+  void shuffle([Random random]) => delegate.shuffle(random);
+
+  @override
+  void sort([int compare(E a, E b)]) => delegate.sort(compare);
+
+  @override
+  List<E> sublist(int start, [int end]) => delegate.sublist(start, end);
+}
+
+/// An implementation of [Iterable] that delegates all methods to another
+/// [Iterable].
+///
+/// Copied from quiver
+///
+/// For instance you can create a FruitIterable like this :
+///
+///     class FruitIterable extends DelegatingIterable<Fruit> {
+///       final Iterable<Fruit> _fruits = [];
+///
+///       Iterable<Fruit> get delegate => _fruits;
+///
+///       // custom methods
+///     }
+abstract class _DelegatingIterable<E> implements Iterable<E> {
+  Iterable<E> get delegate;
+
+  @override
+  bool any(bool test(E element)) => delegate.any(test);
+
+  @override
+  Iterable<T> cast<T>() {
+    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
+    throw UnimplementedError('cast');
+  }
+
+  @override
+  bool contains(Object element) => delegate.contains(element);
+
+  @override
+  E elementAt(int index) => delegate.elementAt(index);
+
+  @override
+  bool every(bool test(E element)) => delegate.every(test);
+
+  @override
+  Iterable<T> expand<T>(Iterable<T> f(E element)) => delegate.expand(f);
+
+  @override
+  E get first => delegate.first;
+
+  @override
+  E firstWhere(bool test(E element), {E orElse()}) =>
+      delegate.firstWhere(test, orElse: orElse);
+
+  @override
+  T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
+      delegate.fold(initialValue, combine);
+
+  @override
+  Iterable<E> followedBy(Iterable<E> other) => delegate.followedBy(other);
+
+  @override
+  void forEach(void f(E element)) => delegate.forEach(f);
+
+  @override
+  bool get isEmpty => delegate.isEmpty;
+
+  @override
+  bool get isNotEmpty => delegate.isNotEmpty;
+
+  @override
+  Iterator<E> get iterator => delegate.iterator;
+
+  @override
+  String join([String separator = '']) => delegate.join(separator);
+
+  @override
+  E get last => delegate.last;
+
+  @override
+  E lastWhere(bool test(E element), {E orElse()}) =>
+      delegate.lastWhere(test, orElse: orElse);
+
+  @override
+  int get length => delegate.length;
+
+  @override
+  Iterable<T> map<T>(T f(E e)) => delegate.map(f);
+
+  @override
+  E reduce(E combine(E value, E element)) => delegate.reduce(combine);
+
+  @override
+  E get single => delegate.single;
+
+  @override
+  E singleWhere(bool test(E element), {E orElse()}) =>
+      delegate.singleWhere(test, orElse: orElse);
+
+  @override
+  Iterable<E> skip(int n) => delegate.skip(n);
+
+  @override
+  Iterable<E> skipWhile(bool test(E value)) => delegate.skipWhile(test);
+
+  @override
+  Iterable<E> take(int n) => delegate.take(n);
+
+  @override
+  Iterable<E> takeWhile(bool test(E value)) => delegate.takeWhile(test);
+
+  @override
+  List<E> toList({bool growable = true}) => delegate.toList(growable: growable);
+
+  @override
+  Set<E> toSet() => delegate.toSet();
+
+  @override
+  Iterable<E> where(bool test(E element)) => delegate.where(test);
+
+  @override
+  Iterable<T> whereType<T>() {
+    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
+    throw UnimplementedError('whereType');
   }
 }

--- a/lib/src/sorted_list.dart
+++ b/lib/src/sorted_list.dart
@@ -63,6 +63,9 @@ class _SortedList<E> extends _DelegatingList<E> {
     return _SortedList<E>._(this, comparator, _comparator);
   }
 
+  @override
+  List<T> cast<T>() => delegate.cast<T>();
+
   int _compare(E element1, E element2) {
     var compare = 0;
     if (_parentComparator != null) {
@@ -113,12 +116,6 @@ abstract class _DelegatingList<E> extends _DelegatingIterable<E>
 
   @override
   Map<int, E> asMap() => delegate.asMap();
-
-  @override
-  _DelegatingList<T> cast<T>() {
-    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
-    throw UnimplementedError('cast');
-  }
 
   @override
   void clear() => delegate.clear();
@@ -234,10 +231,7 @@ abstract class _DelegatingIterable<E> implements Iterable<E> {
   bool any(bool test(E element)) => delegate.any(test);
 
   @override
-  Iterable<T> cast<T>() {
-    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
-    throw UnimplementedError('cast');
-  }
+  Iterable<T> cast<T>() => delegate.cast<T>();
 
   @override
   bool contains(Object element) => delegate.contains(element);
@@ -325,8 +319,5 @@ abstract class _DelegatingIterable<E> implements Iterable<E> {
   Iterable<E> where(bool test(E element)) => delegate.where(test);
 
   @override
-  Iterable<T> whereType<T>() {
-    // TODO(cbracken): Dart 2.0 requires this method to be implemented.
-    throw UnimplementedError('whereType');
-  }
+  Iterable<T> whereType<T>() => delegate.whereType<T>();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   collection: ">=1.14.11 <1.15.0"
   path: ">=1.6.4 <1.7.0"
   crypto: ">=2.1.0 <2.2.0"
-  quiver: ">=2.0.3 <2.1.0"
   characters: ">=0.3.0 <0.4.0"
   time: ^1.1.0
 

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -1,0 +1,253 @@
+import 'dart:math' as math;
+
+import 'package:dartx/dartx.dart';
+import 'package:test/test.dart';
+
+List<int> get _sortedList => [4, 2, 1, 3].sortedBy((it) => it);
+
+void main() {
+  test('sort', () {
+    expect([4, 2, 1, 3].sortedBy((it) => it), [1, 2, 3, 4]);
+  });
+  group('_DelegatingIterable', () {
+    test('any', () {
+      expect(_sortedList.any((it) => it > 2), isTrue);
+    });
+
+    test('cast', () {
+      expect(_sortedList.cast<num>(), isA<Iterable<num>>());
+    });
+
+    test('contains', () {
+      expect(_sortedList.contains(2), isTrue);
+      expect(_sortedList.contains(5), isFalse);
+    });
+
+    test('elementAt', () {
+      expect(_sortedList.elementAt(0), 1);
+    });
+
+    test('every', () {
+      expect(_sortedList.every((it) => it is num), isTrue);
+      expect(_sortedList.every((it) => it is String), isFalse);
+    });
+    test('expand', () {
+      expect(_sortedList.expand((it) => [it, it]), [1, 1, 2, 2, 3, 3, 4, 4]);
+    });
+    test('first', () {
+      expect(_sortedList.first, 1);
+    });
+    test('firstWhere', () {
+      expect(_sortedList.firstWhere((it) => it.isEven), 2);
+    });
+    test('fold', () {
+      expect(_sortedList.fold(0, (a, b) => a + b), 10);
+    });
+    test('followedBy', () {
+      expect(_sortedList.followedBy([2]), [1, 2, 3, 4, 2]);
+    });
+    test('forEach', () {
+      final list = [];
+      _sortedList.forEach(list.add);
+      expect(list, [1, 2, 3, 4]);
+    });
+    test('isEmpty', () {
+      expect(_sortedList.isEmpty, isFalse);
+    });
+    test('isNotEmpty', () {
+      expect(_sortedList.isNotEmpty, isTrue);
+    });
+    test('iterator', () {
+      expect(_sortedList.iterator, isA<Iterator<int>>());
+      var iterator = _sortedList.iterator;
+      expect(iterator.moveNext(), isTrue);
+      expect(iterator.current, 1);
+    });
+    test('join', () {
+      expect(_sortedList.join(','), '1,2,3,4');
+    });
+    test('last', () {
+      expect(_sortedList.last, 4);
+    });
+    test('lastWhere', () {
+      expect(_sortedList.lastWhere((it) => it < 3), 2);
+    });
+    test('length', () {
+      expect(_sortedList.length, 4);
+    });
+    test('map', () {
+      expect(_sortedList.map((it) => it.isEven), [false, true, false, true]);
+    });
+    test('reduce', () {
+      expect(_sortedList.reduce((a, b) => a + b), 10);
+    });
+    test('single', () {
+      expect(() => _sortedList.single, throwsA(isA<StateError>()));
+    });
+    test('singleWhere', () {
+      expect(_sortedList.singleWhere((it) => it == 3), 3);
+    });
+    test('skip', () {
+      expect(_sortedList.skip(1), [2, 3, 4]);
+    });
+    test('skipWhile', () {
+      expect(_sortedList.skipWhile((it) => it < 3), [3, 4]);
+    });
+    test('take', () {
+      expect(_sortedList.take(2), [1, 2]);
+    });
+    test('takeWhile', () {
+      expect(_sortedList.takeWhile((_) => true), [1, 2, 3, 4]);
+    });
+    test('toList', () {
+      expect(_sortedList.toList(), [1, 2, 3, 4]);
+    });
+    test('toSet', () {
+      expect(_sortedList.toSet(), {1, 2, 3, 4});
+    });
+    test('where', () {
+      expect(_sortedList.where((it) => it % 2 == 0), [2, 4]);
+    });
+    test('whereType', () {
+      expect(_sortedList.whereType<int>(), [1, 2, 3, 4]);
+    });
+  });
+  group('_DelegatingList', () {
+    test('operator []', () {
+      expect(_sortedList[2], 3);
+    });
+    test('operator =[]', () {
+      final list = _sortedList;
+      list[2] = 5;
+      expect(list, [1, 2, 5, 4]);
+    });
+    test('operator +', () {
+      expect(_sortedList + [1, 2], [1, 2, 3, 4, 1, 2]);
+    });
+    test('add', () {
+      final list = _sortedList;
+      list.add(1);
+      expect(list, [1, 2, 3, 4, 1]);
+    });
+    test('addAll', () {
+      final list = _sortedList;
+      list.addAll([1, 2]);
+      expect(list, [1, 2, 3, 4, 1, 2]);
+    });
+    test('asMap', () {
+      expect(_sortedList.asMap(), {0: 1, 1: 2, 2: 3, 3: 4});
+    });
+    test('clear', () {
+      final list = _sortedList;
+      list.clear();
+      expect(list, isEmpty);
+    });
+    test('fillRange', () {
+      final list = _sortedList;
+      list.fillRange(0, 2, 6);
+      expect(list, [6, 6, 3, 4]);
+    });
+    test('set first', () {
+      final list = _sortedList;
+      list.first = 6;
+      expect(list, [6, 2, 3, 4]);
+    });
+    test('getRange', () {
+      expect(_sortedList.getRange(0, 2), [1, 2]);
+    });
+    test('indexOf', () {
+      expect(_sortedList.indexOf(2), 1);
+    });
+    test('indexWhere', () {
+      expect(_sortedList.indexWhere((it) => it == 2), 1);
+    });
+    test('insert', () {
+      final list = _sortedList;
+      list.insert(3, 6);
+      expect(list, [1, 2, 3, 6, 4]);
+    });
+    test('insertAll', () {
+      final list = _sortedList;
+      list.insertAll(3, [6, 7]);
+      expect(list, [1, 2, 3, 6, 7, 4]);
+    });
+    test('set last', () {
+      final list = _sortedList;
+      list.last = 5;
+      expect(list, [1, 2, 3, 5]);
+    });
+    test('lastIndexOf', () {
+      expect(_sortedList.lastIndexOf(3), 2);
+    });
+    test('lastIndexWhere', () {
+      expect(_sortedList.lastIndexWhere((it) => it == 3), 2);
+    });
+    test('set length', () {
+      final list = _sortedList;
+      list.length = 5;
+      expect(list, [1, 2, 3, 4, null]);
+    });
+    test('remove', () {
+      final list = _sortedList;
+      list.remove(3);
+      expect(list, [1, 2, 4]);
+    });
+    test('removeAt', () {
+      final list = _sortedList;
+      list.removeAt(2);
+      expect(list, [1, 2, 4]);
+    });
+    test('removeLast', () {
+      final list = _sortedList;
+      list.removeLast();
+      expect(list, [1, 2, 3]);
+    });
+    test('removeRange', () {
+      final list = _sortedList;
+      list.removeRange(1, 3);
+      expect(list, [1, 4]);
+    });
+    test('removeWhere', () {
+      final list = _sortedList;
+      list.removeWhere((it) => it % 2 == 0);
+      expect(list, [1, 3]);
+    });
+    test('replaceRange', () {
+      final list = _sortedList;
+      list.replaceRange(1, 2, [6, 6]);
+      expect(list, [1, 6, 6, 3, 4]);
+    });
+    test('retainWhere', () {
+      final list = _sortedList;
+      list.retainWhere((it) => it % 2 == 0);
+      expect(list, [2, 4]);
+    });
+    test('reversed', () {
+      expect(_sortedList.reversed, [4, 3, 2, 1]);
+    });
+    test('setAll', () {
+      final list = _sortedList;
+      list.setAll(1, [6, 6]);
+      expect(list, [1, 6, 6, 4]);
+    });
+    test('setRange', () {
+      final list = _sortedList;
+      list.setRange(1, 3, [6, 7]);
+      expect(list, [1, 6, 7, 4]);
+    });
+    test('random', () {
+      final r = math.Random(42);
+      final list = _sortedList;
+      list.shuffle(r);
+      expect(list, [2, 3, 1, 4]);
+    });
+    test('sort', () {
+      final list = _sortedList;
+      list.sort((a, b) => a - b);
+      expect(list, [1, 2, 3, 4]);
+    });
+    test('sublist', () {
+      expect(_sortedList.sublist(1, 2), [2]);
+    });
+  });
+}


### PR DESCRIPTION
Many packages use `quiver` as dependency. This increases the risk of having dependency conflicts. Since `dartx` only uses a tiny fraction of quiver it is rather easy to prevent those conflicts by copying the used code.

This PR copies `DelegatingList` and `DelegatingIterable` to `dartx`. Both classes are private.

This change is **not** breaking.