### PR TITLE
Comparison operators for all comparables

### DIFF
--- a/lib/dartx.dart
+++ b/lib/dartx.dart
@@ -12,6 +12,7 @@ import 'package:crypto/crypto.dart' as crypto;
 
 export 'package:time/time.dart';
 
+part 'src/comparable.dart';
 part 'src/function.dart';
 part 'src/iterable_num.dart';
 part 'src/iterable.dart';

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -1,0 +1,9 @@
+part of dartx;
+
+/// Provides comparison operators for [Comparable] types.
+extension ComparableX<T> on Comparable<T> {
+  bool operator <(T other) => compareTo(other) < 0;
+  bool operator <=(T other) => compareTo(other) <= 0;
+  bool operator >(T other) => compareTo(other) > 0;
+  bool operator >=(T other) => compareTo(other) >= 0;
+}

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+import 'package:dartx/dartx.dart';
+
+class _WrappedInt implements Comparable<_WrappedInt> {
+  final int value;
+
+  _WrappedInt(this.value);
+
+  @override
+  int compareTo(_WrappedInt other) => value.compareTo(other.value);
+}
+
+void main() {
+  test('comparable extension operators', () {
+    final one = _WrappedInt(1);
+    final ten = _WrappedInt(10);
+    final hundred = _WrappedInt(100);
+
+    expect(one < ten, isTrue);
+    expect(one < one, isFalse);
+
+    expect(one <= ten, isTrue);
+    expect(ten <= ten, isTrue);
+    expect(hundred <= ten, isFalse);
+
+    expect(ten >= ten, isTrue);
+    expect(ten >= one, isTrue);
+    expect(ten >= hundred, isFalse);
+
+    expect(ten > one, isTrue);
+    expect(ten > ten, isFalse);
+  });
+}


### PR DESCRIPTION
This adds the default comparison operators, (`<`, `<=`, `>=` and `>`) for all types derived from `Comparable`.

While most comparables already implement those operators, this allows to save duplicate work when implementing own comparables. It also makes dealing with comparables that don't override the operators much easier.