### PR TITLE
Iterable<E>.windowed - remove the required transform lambda

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -696,20 +696,15 @@ extension IterableX<E> on Iterable<E> {
     }
   }
 
-  /// Returns a new lazy [Iterable] of results of applying the given [transform]
-  /// function to an each list representing a view over the window of the given
-  /// [size] sliding along this collection with the given [step].
+  /// Returns a new lazy [Iterable] of windows of the given [size] sliding along
+  /// this collection with the given [step].
   ///
-  /// Note that the list passed to the [transform] function is ephemeral and is
-  /// valid only inside that function. You should not store it or allow it to
-  /// escape in some way, unless you made a snapshot of it. The last list may
-  /// have less elements than the given size.
+  /// The last list may have less elements than the given size.
   ///
   /// Both [size] and [step] must be positive and can be greater than the number
   /// of elements in this collection.
-  Iterable<R> windowed<R>(
-    int size,
-    R transform(List<E> window), {
+  Iterable<List<E>> windowed(
+    int size, {
     int step = 1,
     bool partialWindows = false,
   }) sync* {
@@ -724,20 +719,20 @@ extension IterableX<E> on Iterable<E> {
         }
         buffer.add(element);
         if (buffer.length == size) {
-          yield transform(buffer);
+          yield buffer;
           buffer = <E>[];
           skip = gap;
         }
       }
       if (buffer.isNotEmpty && (partialWindows || buffer.length == size)) {
-        yield transform(buffer);
+        yield buffer;
       }
     } else {
       var buffer = ListQueue<E>(size);
       for (var element in this) {
         buffer.add(element);
         if (buffer.length == size) {
-          yield transform(buffer.toList());
+          yield buffer.toList();
           for (var i = 0; i < step; i++) {
             buffer.removeFirst();
           }
@@ -745,13 +740,13 @@ extension IterableX<E> on Iterable<E> {
       }
       if (partialWindows) {
         while (buffer.length > step) {
-          yield transform(buffer.toList());
+          yield buffer.toList();
           for (var i = 0; i < step; i++) {
             buffer.removeFirst();
           }
         }
         if (buffer.isNotEmpty) {
-          yield transform(buffer.toList());
+          yield buffer.toList();
         }
       }
     }

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -542,13 +542,19 @@ void main() {
 
     group('.windowed()', () {
       test('size 1', () {
-        expect([].windowed(1, (list) => 1), []);
-        expect([0, 1, 2, 3, 4, 5].windowed(1, (list) => list.first),
-            [0, 1, 2, 3, 4, 5]);
+        expect([].windowed(1), []);
+        expect([0, 1, 2, 3, 4, 5].windowed(1), [
+          [0],
+          [1],
+          [2],
+          [3],
+          [4],
+          [5]
+        ]);
       });
 
       test('size 4', () {
-        var result = [0, 1, 2, 3, 4, 5].windowed(4, (list) => list);
+        var result = [0, 1, 2, 3, 4, 5].windowed(4);
         expect(result, [
           [0, 1, 2, 3],
           [1, 2, 3, 4],
@@ -557,8 +563,7 @@ void main() {
       });
 
       test('partialWindows', () {
-        var result = [0, 1, 2, 3, 4, 5]
-            .windowed(4, (list) => list, partialWindows: true);
+        var result = [0, 1, 2, 3, 4, 5].windowed(4, partialWindows: true);
         expect(result, [
           [0, 1, 2, 3],
           [1, 2, 3, 4],
@@ -570,7 +575,7 @@ void main() {
       });
 
       test('steps', () {
-        var result = [0, 1, 2, 3, 4, 5].windowed(3, (list) => list, step: 2);
+        var result = [0, 1, 2, 3, 4, 5].windowed(3, step: 2);
         expect(result, [
           [0, 1, 2],
           [2, 3, 4]
@@ -578,8 +583,8 @@ void main() {
       });
 
       test('steps & partialWindows', () {
-        var result = [0, 1, 2, 3, 4, 5]
-            .windowed(3, (list) => list, step: 2, partialWindows: true);
+        var result =
+            [0, 1, 2, 3, 4, 5].windowed(3, step: 2, partialWindows: true);
         expect(result, [
           [0, 1, 2],
           [2, 3, 4],


### PR DESCRIPTION
Fixes #19

Note: This is a breaking change