### PR TITLE
Fix for #33: Add new extension methods for composing Comparators, make .thenBy and .thenWith composable by an arbitrary amount of Comparators

### DIFF
--- a/lib/dartx.dart
+++ b/lib/dartx.dart
@@ -13,6 +13,7 @@ import 'package:crypto/crypto.dart' as crypto;
 export 'package:time/time.dart';
 
 part 'src/comparable.dart';
+part 'src/comparator.dart';
 part 'src/function.dart';
 part 'src/iterable_num.dart';
 part 'src/iterable.dart';

--- a/lib/src/comparator.dart
+++ b/lib/src/comparator.dart
@@ -1,6 +1,6 @@
 part of dartx;
 
-extension ComposeComparable<T> on Comparator<T> {
+extension CompararatorX<T> on Comparator<T> {
   /// return a new comparator,
   /// that sorts the items first by the criteria of this comparator,
   /// then by the criteria of the given comparator

--- a/lib/src/comparator.dart
+++ b/lib/src/comparator.dart
@@ -1,0 +1,19 @@
+part of dartx;
+
+extension ComposeComparable<T> on Comparator<T> {
+  /// return a new comparator,
+  /// that sorts the items first by the criteria of this comparator,
+  /// then by the criteria of the given comparator
+  Comparator<T> compose(Comparator<T> then) {
+    return (a, b) {
+      final first = this(a, b);
+      if (first != 0) {
+        return first;
+      }
+      return then(a, b);
+    };
+  }
+
+  /// reverse the sort order of this comparator
+  Comparator<T> reverse() => (a, b) => this(b, a);
+}

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -248,7 +248,7 @@ extension IterableX<E> on Iterable<E> {
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
   _SortedList<E> sortedWith(Comparator<E> comparator) {
-    return _SortedList<E>._(this, comparator, null);
+    return _SortedList<E>._(this, comparator);
   }
 
   /// Creates a string from all the elements separated using [separator] and

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -249,5 +249,51 @@ void main() {
     test('sublist', () {
       expect(_sortedList.sublist(1, 2), [2]);
     });
+
+    test('can sort items by 3 comparators', () {
+      const itemList = [
+        Item(0, 1, 2),
+        Item(2, 1, 0),
+        Item(1, 2, 0),
+      ];
+
+      final sorted = itemList
+          .sortedBy((item) => item.a)
+          .thenBy((item) => item.b)
+          .thenBy((item) => item.c);
+
+      expect(
+          sorted.toList(),
+          equals(const [
+            Item(0, 1, 2),
+            Item(1, 2, 0),
+            Item(2, 1, 0),
+          ]));
+    });
   });
+}
+
+class Item {
+  final int a;
+  final int b;
+  final int c;
+
+  const Item(this.a, this.b, this.c);
+
+  @override
+  String toString() {
+    return 'Item{a: $a, b: $b, c: $c}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Item &&
+          runtimeType == other.runtimeType &&
+          a == other.a &&
+          b == other.b &&
+          c == other.c;
+
+  @override
+  int get hashCode => a.hashCode ^ b.hashCode ^ c.hashCode;
 }


### PR DESCRIPTION
This fixes #33.

This PR adds:

- A test for a list that gets sorted by 3 different comparators
- Extension methods for composing Comparators

This PR changes:
- The behavior or _SortedList when using more than 2 comparators. The _parentComparator instance variable is removed, instead a single Comparator is used. When calling .thenBy, .thenWith, etc., a new Comparator is created using the existing comparator and the given comparator. 
