### PR TITLE
Add String.toBool

### DIFF
--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -123,4 +123,10 @@ extension StringX on String {
   /// print('message digest'.md5); //f96b697d7cb7938d525a2f31aaf161d0
   /// ```
   String get md5 => crypto.md5.convert(toUtf8()).toString();
+
+  /// Returns true if it equals to 'true' or 'on' or '1',
+  /// otherwise returns false
+  bool get toBool => toLowerCase() == 'true'
+    || toLowerCase() == 'on'
+    || this == '1';
 }

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -142,5 +142,23 @@ void main() {
           '57edf4a22be3c955ac49da2e2107b67a'
       );
     });
+
+    test('.toBool', () async {
+      expect('true'.toBool, true);
+      expect(''.toBool, false);
+
+      expect('TRUE'.toBool, true);
+      expect('True'.toBool, true);
+      expect('truE'.toBool, true);
+      expect('tRue'.toBool, true);
+
+      expect('false'.toBool, false);
+      expect('FALSE'.toBool, false);
+
+      expect('on'.toBool, true);
+      expect('ON'.toBool, true);
+      expect('off'.toBool, false);
+      expect('OFF'.toBool, false);
+    });
   });
 }


### PR DESCRIPTION
Original purpose was `Object.isTrue`:

```dart
extension on Object {
  bool get isTrue => isTrueOrNull ?? false;

  bool get isTrueOrNull {
    return this is bool ? this
       : this is String ? this.isTrue // String.isTrue
       : this is int ? this.isTrue // int.isTrue
       : this is double ? this.isTrue // double.isTrue
       : this is Iterable ? this.isTrue // Iterable.isTrue
       : null;
  }
}
```

According to the comments, we're going to add `String.toBool` only for this PR.