### PR TITLE
Iterable<T>.containsAny(Iterable<T>)

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -172,6 +172,15 @@ extension IterableX<E> on Iterable<E> {
     return true;
   }
 
+  /// Checks if any elements in the specified [collection] are contained in
+  /// this collection.
+  bool containsAny(Iterable<E> collection) {
+    for (var element in collection) {
+      if (contains(element)) return true;
+    }
+    return false;
+  }
+
   /// Returns true if this collection is structurally equal to the [other]
   /// collection.
   ///

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -164,6 +164,14 @@ void main() {
       expect(list1.contentEquals(list1), true);
     });
 
+    test('.containsAny()', () {
+      var list1 = const [1, 2, 3, 4, 5];
+      var list2 = const [1, 3, 6];
+
+      expect(list1.containsAny(list2), true);
+      expect(list2.containsAny([2, 4, 7]), false);
+    });
+
     test('.contentEquals()', () {
       var list1 = const ['test', 'test', 'tom', 'true'];
       var list2 = const ['test', 't', 'te', 'tes'];


### PR DESCRIPTION

Add Iterable.containsAny(listB).
This will search through a list and returns true if any elements in listB are present in _this_ 