### PR TITLE
Adding "radix" to toInt and toIntOrNUll

### DIFF
--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -60,9 +60,7 @@ class IntRange extends IterableBase<int> {
 
   @override
   Iterator<int> get iterator => _IntRangeIterator(_first, _last, stepSize);
-}
 
-extension IntRangeX on IntRange {
   /// Creates a [IntRange] with a different [stepSize],
   /// keeps first and last value
   IntRange step(int step) => IntRange(_first, _last, step: step);

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -60,7 +60,9 @@ class IntRange extends IterableBase<int> {
 
   @override
   Iterator<int> get iterator => _IntRangeIterator(_first, _last, stepSize);
+}
 
+extension IntRangeX on IntRange {
   /// Creates a [IntRange] with a different [stepSize],
   /// keeps first and last value
   IntRange step(int step) => IntRange(_first, _last, step: step);

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -96,11 +96,25 @@ extension StringX on String {
   bool get isInt => toIntOrNull() != null;
 
   /// Parses the string as an [int] number and returns the result.
-  int toInt() => int.parse(this);
+  ///
+  /// The [radix] must be in the range 2..36. The digits used are
+  /// first the decimal digits 0..9, and then the letters 'a'..'z' with
+  /// values 10 through 35. Also accepts upper-case letters with the same
+  /// values as the lower-case ones.
+  ///
+  /// If no [radix] is given then it defaults to 10.
+  int toInt({int radix}) => int.parse(this, radix: radix);
 
   /// Parses the string as an [int] number and returns the result or `null` if
   /// the string is not a valid representation of a number.
-  int toIntOrNull() => int.tryParse(this);
+  ///
+  /// The [radix] must be in the range 2..36. The digits used are
+  /// first the decimal digits 0..9, and then the letters 'a'..'z' with
+  /// values 10 through 35. Also accepts upper-case letters with the same
+  /// values as the lower-case ones.
+  ///
+  /// If no [radix] is given then it defaults to 10.
+  int toIntOrNull({int radix}) => int.tryParse(this, radix: radix);
 
   bool get isDouble => toDoubleOrNull() != null;
 

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -73,16 +73,18 @@ void main() {
       expect('123456789'.isInt, true);
     });
 
-    test('.toInt()', () {
-      expect('0'.toInt(), 0);
-      expect('1'.toInt(), 1);
-      expect('123456789'.toInt(), 123456789);
-    });
+    group('.toInt()', () {
+      test('with radix', () {
+        expect('100'.toInt(radix: 2), 4);
+        expect('100'.toInt(radix: 16), 256);
+        expect('FF'.toInt(radix: 16), 255);
+      });
 
-    test('.toInt(radix)', () {
-      expect('100'.toInt(radix: 2), 4);
-      expect('100'.toInt(radix: 16), 256);
-      expect('FF'.toInt(radix: 16), 255);
+      test('without radix', () {
+        expect('0'.toInt(), 0);
+        expect('1'.toInt(), 1);
+        expect('123456789'.toInt(), 123456789);
+      });
     });
 
     test('.toIntOrNull()', () {

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -79,6 +79,12 @@ void main() {
       expect('123456789'.toInt(), 123456789);
     });
 
+    test('.toInt(radix)', () {
+      expect('100'.toInt(radix: 2), 4);
+      expect('100'.toInt(radix: 16), 256);
+      expect('FF'.toInt(radix: 16), 255);
+    });
+
     test('.toIntOrNull()', () {
       expect(''.toIntOrNull(), null);
       expect('a'.toIntOrNull(), null);
@@ -129,18 +135,15 @@ void main() {
       expect('message digest'.md5, 'f96b697d7cb7938d525a2f31aaf161d0');
       expect('ഐ⌛酪Б👨‍👨‍👧‍👦'.md5, 'c7834eff7c967101cfb65b8f6d15ad46');
       expect(
-          'abcdefghijklmnopqrstuvwxyz'.md5,
-          'c3fcd3d76192e4007dfb496cca67e13b'
-      );
+          'abcdefghijklmnopqrstuvwxyz'.md5, 'c3fcd3d76192e4007dfb496cca67e13b');
       expect(
           'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'.md5,
-          'd174ab98d277d9f5a5611c2c9f419d9f'
-      );
+          'd174ab98d277d9f5a5611c2c9f419d9f');
       expect(
           '12345678901234567890123456789012345678901234567890123456789012'
-              '345678901234567890'.md5,
-          '57edf4a22be3c955ac49da2e2107b67a'
-      );
+                  '345678901234567890'
+              .md5,
+          '57edf4a22be3c955ac49da2e2107b67a');
     });
   });
 }


### PR DESCRIPTION
I've added an optional parameter to `String.toInt` and `String.toIntOrNull` to parse strings in binary or hexadecimal format (or whatever radix you want).