### PR TITLE
Add Comparable.rangeTo() to ComparableRange()

### DIFF
--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -36,4 +36,17 @@ extension ComparableX<T extends Comparable<T>> on T {
   /// or the [maximumValue] otherwise.
   T coerceAtMost(T maximumValue) =>
       this > maximumValue ? maximumValue : this;
+
+  /// Returns true if between [first] and [endInclusive].
+  ///
+  /// Equivalent to `ComparableRange(first, endInclusive).contains(this)`
+  ///
+  /// Uncomment this if it's useful for everyone
+  //bool between(T first, T endInclusive) =>
+  //  first <= this && this <= endInclusive;
+
+  /// Returns true if in the [range].
+  /// Uncomment this if it's useful for everyone
+  //bool inRange(ComparableRange<T> range) => range.contains(this);
+
 }

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -1,5 +1,69 @@
 part of dartx;
 
+/// Represents a range of values (for example, numbers or characters).
+abstract class ClosedRange<T extends Comparable<T>> {
+  T get start;
+  T get endInclusive;
+
+  bool contains(T value);
+  bool get isEmpty;
+
+  @override
+  String toString() => '$start..$endInclusive';
+
+  @override
+  bool operator ==(Object other) =>
+    (other is ClosedRange) && (isEmpty && other.isEmpty ||
+     start == other.start && endInclusive == other.endInclusive);
+
+  @override
+  int get hashCode =>
+    isEmpty ? -1 : 31 * start.hashCode + endInclusive.hashCode;
+}
+
+/// Represents a range of [Comparable] values.
+class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
+  ComparableRange(T first, T endInclusive)
+      : _first = first,
+        _last = endInclusive,
+        assert(() {
+          if (first == null) throw ArgumentError("start can't be null");
+          if (endInclusive == null) {
+            throw ArgumentError("endInclusive can't be null");
+          }
+          return true;
+        }());
+
+  /// The first element in the range.
+  final T _first;
+
+  /// The last element in the range.
+  final T _last;
+
+  @override
+  bool contains(T value) {
+    return start <= value && value <= endInclusive;
+  }
+
+  @override
+  T get endInclusive => _last;
+
+  @override
+  bool get isEmpty => !(start <= endInclusive);
+
+  @override
+  T get start => _first;
+
+}
+
+extension ComparableRangeX<T extends Comparable<T>> on T {
+  /// Creates a [ComparableRange] from this [Comparable] value
+  /// to the specified [that] value.
+  /// This value needs to be smaller than [that] value,
+  /// otherwise the returned range will be empty.
+  ComparableRange<T> rangeTo(T that) => ComparableRange<T>(this, that);
+}
+
 extension IntRangeExtension on int {
   /// Creates a [IntRange] with a step count of 1
   ///
@@ -28,7 +92,9 @@ extension IntRangeExtension on int {
 
 /// A iterable range between two ints which is iterable with a specific step
 /// size
-class IntRange extends IterableBase<int> {
+///
+/// int doesn't extend Comparable<int>, uses ClosedRange<num> instead.
+class IntRange extends IterableBase<int> implements ClosedRange<num> {
   /// Creates a range between two ints ([first], [endInclusive]) which can be
   /// iterated through.
   ///
@@ -60,6 +126,24 @@ class IntRange extends IterableBase<int> {
 
   @override
   Iterator<int> get iterator => _IntRangeIterator(_first, _last, stepSize);
+
+  @override
+  int get endInclusive => _last;
+
+  @override
+  int get start => _first;
+
+  @override
+  String toString() => '$start..$endInclusive';
+
+  @override
+  bool operator ==(Object other) =>
+    (other is ClosedRange) && (isEmpty && other.isEmpty ||
+     start == other.start && endInclusive == other.endInclusive);
+
+  @override
+  int get hashCode =>
+    isEmpty ? -1 : 31 * start.hashCode + endInclusive.hashCode;
 }
 
 extension IntRangeX on IntRange {

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -49,6 +49,56 @@ void main() {
           DateTime(1984, 11, 1));
     });
 
+    //test('.between()', () {
+    //  expect(
+    //    DateTime(1984, 11, 19)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2019, 11, 19)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 1)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 2)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    false
+    //  );
+    //  expect(
+    //    DateTime(1984, 11, 18)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    false
+    //  );
+    //});
+
+    //test('.inRange()', () {
+    //  final range = ComparableRange(
+    //    DateTime(1984, 11, 19), DateTime(2020, 1, 1)
+    //  );
+
+    //  expect(
+    //    DateTime(1984, 11, 19).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2019, 11, 19).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 1).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 2).inRange(range), false
+    //  );
+    //  expect(
+    //    DateTime(1984, 11, 18).inRange(range), false
+    //  );
+    //});
+
     test('comparable extension operators', () {
       final one = _WrappedInt(1);
       final ten = _WrappedInt(10);

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -14,6 +14,57 @@ void main() {
     });
   });
 
+  group('ClosedRange', () {
+    test('==', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)) ==
+        ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+        isTrue
+      );
+
+      final num zero = 0.0;
+      final num one = 1.0;
+      final numRange = zero.rangeTo(one);
+      // ComparableRange<num>.==(IntRange)
+      expect(0.rangeTo(1) == numRange, isTrue);
+    });
+
+    test('.toString', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).toString(),
+        "1984-11-19 00:00:00.000..2020-01-01 00:00:00.000"
+      );
+      final num zero = 0;
+      final num one = 1;
+      final numRange = zero.rangeTo(one);
+      expect(numRange.toString(), '0..1');
+      final num zeroDouble = 0.0;
+      final num oneDouble = 1.0;
+      expect(zeroDouble.rangeTo(oneDouble).toString(), '0.0..1.0');
+    });
+  });
+
+  group('ComparableRange', () {
+    test('.contains()', () {
+      final dateRange = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
+      expect(dateRange.contains(DateTime(1984, 11, 19)), isTrue);
+      expect(dateRange.contains(DateTime(2019, 11, 19)), isTrue);
+      expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
+      expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
+      expect(dateRange.contains(DateTime(1984, 11, 18)), isFalse);
+    });
+    test('.isEmpty', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).isEmpty,
+        false
+      );
+      expect(
+        DateTime(2020, 1, 1).rangeTo(DateTime(1984, 11, 19)).isEmpty,
+        isTrue
+      );
+    });
+  });
+
   group('rangeTo with step()', () {
     test('upwards', () {
       expect(5.rangeTo(10).step(2).toList(), [5, 7, 9]);
@@ -49,6 +100,10 @@ void main() {
       expect(0.rangeTo(10).step(2).contains(1), isFalse);
       expect(0.rangeTo(10).step(2).contains(0), isTrue);
       expect(0.rangeTo(10).step(2).contains(10), isTrue);
+    });
+
+    test('contains', () {
+      expect(0.rangeTo(1).toString(), '0..1');
     });
   });
 }


### PR DESCRIPTION
```dart
// `ComparableRange.contains()` equivalent to 
//
//   bool Comparable<T>.between(T first, T endInclusive) =>
//     first <= this && this <= endInclusive;
//
// NOTICE: it's not equivalent to `IntRange.contains()` for now unless inherits `ComparableRange.contains()`.
// ref. https://github.com/JetBrains/kotlin-native/blob/master/runtime/src/main/kotlin/kotlin/ranges/Ranges.kt#L41
expect(
    DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1).contains(DateTime(1984, 11, 19)),
    isTrue
);
```


Resolve #35