### PR TITLE
Add median to iterable_num

### DIFF
--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -42,7 +42,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Null values are ignored.
   double median() {
     if (length == 0) throw StateError('No elements in collection');
-    var a = toList().removeWhere((item) => item == null)..sort();
+    var a = toList()..removeWhere((item) => item == null)..a.sort();
     var l = a.length;
     if (l.isOdd) {
       return a[(l/2).floor()].toDouble();

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -6,7 +6,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   ///
   /// All elements have to be of type [num] or `null`. `null` elements are not
   /// counted.
-  T get sum {
+  T sum() {
     var sum = (T == int ? 0 : 0.0) as T;
     for (var current in this) {
       if (current != null) {
@@ -19,7 +19,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Returns the average of all elements in the collection.
   ///
   /// `null` elements are counted as 0. Empty collections throw an error.
-  double get average {
+  double average() {
     var count = 0;
     num sum = 0;
     for (var current in this) {
@@ -39,7 +39,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Returns the median of the elements in this collection.
   ///
   /// Empty collections throw an error.
-  double get median {
+  double median() {
     if (length == 0) throw StateError('No elements in collection');
     var a = toList()..sort();
     var l = length;

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -42,7 +42,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Null values are ignored.
   double median() {
     if (length == 0) throw StateError('No elements in collection');
-    var a = toList()..removeWhere((item) => item == null)..a.sort();
+    var a = toList()..removeWhere((item) => item == null)..sort();
     var l = a.length;
     if (l.isOdd) {
       return a[(l/2).floor()].toDouble();

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -39,9 +39,10 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Returns the median of the elements in this collection.
   ///
   /// Empty collections throw an error.
+  /// Null values are ignored
   double median() {
     if (length == 0) throw StateError('No elements in collection');
-    var a = toList()..sort();
+    var a = toList().removeWhere((item) => item is null)..sort();
     var l = length;
     if (l.isOdd) {
       return a[(l/2).floor()].toDouble();

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -39,10 +39,10 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Returns the median of the elements in this collection.
   ///
   /// Empty collections throw an error.
-  /// Null values are ignored
+  /// Null values are ignored.
   double median() {
     if (length == 0) throw StateError('No elements in collection');
-    var a = toList().removeWhere((item) => item is null)..sort();
+    var a = toList().removeWhere((item) => item == null)..sort();
     var l = a.length;
     if (l.isOdd) {
       return a[(l/2).floor()].toDouble();

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -6,7 +6,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   ///
   /// All elements have to be of type [num] or `null`. `null` elements are not
   /// counted.
-  T sum() {
+  T get sum {
     var sum = (T == int ? 0 : 0.0) as T;
     for (var current in this) {
       if (current != null) {
@@ -18,9 +18,8 @@ extension IterableNumX<T extends num> on Iterable<T> {
 
   /// Returns the average of all elements in the collection.
   ///
-  /// All elements must be of type [Comparable].
-  /// `null` elements are counted as 0. Empty collections return null.
-  double average() {
+  /// `null` elements are counted as 0. Empty collections throw an error.
+  double get average {
     var count = 0;
     num sum = 0;
     for (var current in this) {
@@ -34,6 +33,23 @@ extension IterableNumX<T extends num> on Iterable<T> {
       throw StateError('No elements in collection');
     } else {
       return sum / count;
+    }
+  }
+  
+  /// Returns the median of the elements in this collection.
+  ///
+  /// Empty collections throw an error.
+  double get median {
+    if (length == 0) throw StateError('No elements in collection');
+    var a = toList()..sort();
+    var l = length;
+    if (l.isOdd) {
+      return a[(l/2).floor()].toDouble();
+    }
+    else {
+      var x = a[(l/2).floor()];
+      var y = a[(l/2).floor()-1];
+      return (x+y)/2;
     }
   }
 }

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -43,7 +43,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   double median() {
     if (length == 0) throw StateError('No elements in collection');
     var a = toList().removeWhere((item) => item is null)..sort();
-    var l = length;
+    var l = a.length;
     if (l.isOdd) {
       return a[(l/2).floor()].toDouble();
     }

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -35,22 +35,23 @@ extension IterableNumX<T extends num> on Iterable<T> {
       return sum / count;
     }
   }
-  
+
   /// Returns the median of the elements in this collection.
   ///
   /// Empty collections throw an error.
-  /// Null values are ignored.
+  /// `null` values are ignored.
   double median() {
     if (length == 0) throw StateError('No elements in collection');
-    var a = toList()..removeWhere((item) => item == null)..sort();
-    var l = a.length;
-    if (l.isOdd) {
-      return a[(l/2).floor()].toDouble();
-    }
-    else {
-      var x = a[(l/2).floor()];
-      var y = a[(l/2).floor()-1];
-      return (x+y)/2;
+    final values = toList()
+      ..removeWhere((item) => item == null)
+      ..sort();
+    final size = values.length;
+    if (size.isOdd) {
+      return values[(size / 2).floor()].toDouble();
+    } else {
+      final x = values[(size / 2).floor()];
+      final y = values[(size / 2).floor() - 1];
+      return (x + y) / 2;
     }
   }
 }

--- a/test/iterable_num_test.dart
+++ b/test/iterable_num_test.dart
@@ -22,5 +22,13 @@ void main() {
       expect([1, 2, 3, 4, 5].average(), 3.0);
       expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].average(), 3.0);
     });
+    
+    test('.median()', () {
+      expect(() => <int>[].median(), throwsStateError);
+      expect([1, 2, 3, 4, 5].median(), 3);
+      expect([5, 3, 2, 4, 1].median(), 3);
+      expect([5, 3, 2, 4, 1, 1].median(), 2.5);
+      expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].median(), throwsStateError);
+    });
   });
 }

--- a/test/iterable_num_test.dart
+++ b/test/iterable_num_test.dart
@@ -22,13 +22,21 @@ void main() {
       expect([1, 2, 3, 4, 5].average(), 3.0);
       expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].average(), 3.0);
     });
-    
+
     test('.median()', () {
       expect(() => <int>[].median(), throwsStateError);
+      // odd
       expect([1, 2, 3, 4, 5].median(), 3);
       expect([5, 3, 2, 4, 1].median(), 3);
+
+      // even
       expect([5, 3, 2, 4, 1, 1].median(), 2.5);
+
+      // removes nulls
       expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].median(), 3.5);
+
+      // handles double values
+      expect([1.5, 2, 2.5, 4, 5].median(), 2.5);
     });
   });
 }

--- a/test/iterable_num_test.dart
+++ b/test/iterable_num_test.dart
@@ -28,7 +28,7 @@ void main() {
       expect([1, 2, 3, 4, 5].median(), 3);
       expect([5, 3, 2, 4, 1].median(), 3);
       expect([5, 3, 2, 4, 1, 1].median(), 2.5);
-      expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].median(), throwsStateError);
+      expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].median(), 3.5);
     });
   });
 }


### PR DESCRIPTION
I added a median function to iterable_num.

I also reformatted the zero argument functions to getters (which improves readability IMO). I also updated the documentation of average to reflect the actual function.

EDIT: probably shouldn't have changed to getters; it's pretty useless and might break code unnecessarily. Will update PR...