### PR TITLE
Added .asStreamAwaited() function for iterables of futures

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1005,3 +1005,18 @@ extension IterableX<E> on Iterable<E> {
     return [t, f];
   }
 }
+
+extension IterableFutureX<E> on Iterable<Future<E>> {
+  /// Create a stream from a group of futures.
+  ///
+  /// The stream reports the results of the futures on the stream in the order
+  /// in which the futures complete.
+  /// Each future provides either a data event or an error event,
+  /// depending on how the future completes.
+  ///
+  /// If some futures have already completed when `Stream.fromFutures` is called,
+  /// their results will be emitted in some unspecified order.
+  ///
+  /// When all futures have completed, the stream is closed.
+  Stream<E> asStreamAwaited() => Stream.fromFutures(this);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,4 @@ dependencies:
 dev_dependencies:
   test: ^1.9.2
   pedantic: ^1.8.0
+  fake_async: ^1.1.0

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:math';
-
+import 'package:async/async.dart';
 import 'package:dartx/dartx.dart';
 import 'package:test/test.dart';
 
@@ -616,10 +617,15 @@ void main() {
       });
 
       test('.asStreamAwaited()', () {
-        expect(
-          [Future.value(0), Future.value(1)].asStreamAwaited(),
-          emitsInOrder([0, 1]),
-        );
+        var queue = StreamQueue([
+          Future.value(0),
+          Future.value(1),
+          Future.value(2),
+          Future.value(3),
+        ].asStreamAwaited());
+
+        // Ignore lines from the process until it's about to emit the URL.
+        expect(queue, emitsInOrder([0, 1, 2, 3]));
       });
     });
 

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -624,7 +624,6 @@ void main() {
           Future.value(3),
         ].asStreamAwaited());
 
-        // Ignore lines from the process until it's about to emit the URL.
         expect(queue, emitsInOrder([0, 1, 2, 3]));
       });
     });

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -609,9 +609,18 @@ void main() {
       );
     });
 
-    test('.asStream()', () {
-      expect([0, 1, 2, 3, 4, 5].asStream(), emitsInOrder([0, 1, 2, 3, 4, 5]));
-      expect([100, 99, 98, 95].asStream(), emitsInOrder([100, 99, 98, 95]));
+    group('.asStream()', () {
+      test('.asStream()', () {
+        expect([0, 1, 2, 3, 4, 5].asStream(), emitsInOrder([0, 1, 2, 3, 4, 5]));
+        expect([100, 99, 98, 95].asStream(), emitsInOrder([100, 99, 98, 95]));
+      });
+
+      test('.asStreamAwaited()', () {
+        expect(
+          [Future.value(0), Future.value(1)].asStreamAwaited(),
+          emitsInOrder([0, 1]),
+        );
+      });
     });
 
     test('.flatten()', () {


### PR DESCRIPTION
My last request did not contained a case for Iterables of Futures.
I am adding it now with the name .asStreamAwaited() wich is a shortcut for calling `Stream.fromFutures`.

It's different from the latest one beacause this one awaits for the future completions and emits them in the order of completion.