### PR TITLE
Preserving type for 'flatten' methods

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1005,3 +1005,17 @@ extension IterableX<E> on Iterable<E> {
     return [t, f];
   }
 }
+
+//This extension helps preserving types when using the flatten methods.
+extension IterableIterableX<R> on Iterable<Iterable<R>> {
+  Iterable<R> flatten() sync* {
+    for (var current in this) {
+      yield* current;
+    }
+  }
+}
+
+//This extension helps preserving types when using the flatten methods.
+extension IterableListX<R> on Iterable<List<R>> {
+  Iterable<R> flatten() => IterableIterableX(this).flatten();
+}

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -620,9 +620,22 @@ void main() {
       var list = [
         [0, 0, 0],
         [1, 1, 1],
-        [2, 2, 2]
+        [2, 2, 2],
       ];
+
       expect(list.flatten(), [0, 0, 0, 1, 1, 1, 2, 2, 2]);
+      expect(list.flatten(), isA<Iterable<int>>());
+      expect(list.flatten().toList(), isA<List<int>>());
+
+      var iterableOfIterables = Iterable.generate(3, (index) sync* {
+        yield index;
+        yield index + 1;
+        yield index + 2;
+      });
+
+      expect(iterableOfIterables.flatten(), [0, 1, 2, 1, 2, 3, 2, 3, 4]);
+      expect(iterableOfIterables.flatten(), isA<Iterable<int>>());
+      expect(iterableOfIterables.flatten().toList(), isA<List<int>>());
     });
 
     group('.cycle()', () {


### PR DESCRIPTION
Based on this discussion: https://github.com/dart-lang/sdk/issues/40315, I added two more extensions to Iterable class.

The actual implementation has a method `flatten` that returns an `Interable<dynamic>`, wich loses type on returned Iterable.
Those two new extensions will help preserving the type for Lists and Iterables  :)

(tests included)