### PR TITLE
Make .flatten() type-safe

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -769,19 +769,6 @@ extension IterableX<E> on Iterable<E> {
     }
   }
 
-  /// Returns a new lazy [Iterable] of all elements from all collections in this
-  /// collection.
-  ///
-  /// ```dart
-  /// var nestedList = List([[1, 2, 3], [4, 5, 6]]);
-  /// var flattened = nestedList.flatten(); // [1, 2, 3, 4, 5, 6]
-  /// ```
-  Iterable<dynamic> flatten() sync* {
-    for (var current in this) {
-      yield* (current as Iterable);
-    }
-  }
-
   /// Returns a new lazy [Iterable] which iterates over this collection [n]
   /// times.
   ///
@@ -1006,16 +993,17 @@ extension IterableX<E> on Iterable<E> {
   }
 }
 
-//This extension helps preserving types when using the flatten methods.
-extension IterableIterableX<R> on Iterable<Iterable<R>> {
-  Iterable<R> flatten() sync* {
+extension IterableIterableX<E> on Iterable<Iterable<E>> {
+  /// Returns a new lazy [Iterable] of all elements from all collections in this
+  /// collection.
+  ///
+  /// ```dart
+  /// var nestedList = List([[1, 2, 3], [4, 5, 6]]);
+  /// var flattened = nestedList.flatten(); // [1, 2, 3, 4, 5, 6]
+  /// ```
+  Iterable<E> flatten() sync* {
     for (var current in this) {
       yield* current;
     }
   }
-}
-
-//This extension helps preserving types when using the flatten methods.
-extension IterableListX<R> on Iterable<List<R>> {
-  Iterable<R> flatten() => IterableIterableX(this).flatten();
 }

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1005,3 +1005,17 @@ extension IterableX<E> on Iterable<E> {
     return [t, f];
   }
 }
+
+//This extension helps preserving types when using the flatten methods.
+extension IterableIterableX<R> on Iterable<Iterable<R>> {
+  Iterable<R> flatten() sync* {
+    for (var current in this) {
+      yield* current;
+    }
+  }
+}
+
+//This extension helps preserving types when using the flatten methods.
+extension IterableListX<R> on Iterable<List<R>> {
+  Iterable<R> flatten() => IterableIterableX(this).flatten();
+}

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -154,3 +154,23 @@ extension ListX<E> on List<E> {
     _mergeSort(this, start: start, end: end, compare: comparator);
   }
 }
+
+extension ListListX<E> on List<List<E>> {
+  /// Returns a new [List] of all elements from all lists in this
+  /// [List].
+  ///
+  /// ```dart
+  /// var nestedList = [[1, 2, 3], [4, 5, 6]];
+  /// var flattened = nestedList.flatten(); // [1, 2, 3, 4, 5, 6]
+  /// ```
+  ///
+  ///
+  /// This is a specialization of [IterableIterableX].flatten() which allows
+  /// accessing elements by index afterwards
+  ///
+  /// ```dart
+  /// var flat = [['a', 'b'], ['d', 'f']].flatten();
+  /// print(flat[2]); // prints b
+  /// ```
+  List<E> flatten() => [for (var list in this) ...list];
+}

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -169,8 +169,8 @@ extension ListListX<E> on List<List<E>> {
   /// accessing elements by index afterwards
   ///
   /// ```dart
-  /// var flat = [['a', 'b'], ['d', 'f']].flatten();
-  /// print(flat[2]); // prints b
+  /// var flat = [['a', 'b'], ['c', 'd']].flatten();
+  /// print(flat[2]); // prints "c"
   /// ```
   List<E> flatten() => [for (var list in this) ...list];
 }

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -614,28 +614,33 @@ void main() {
       expect([100, 99, 98, 95].asStream(), emitsInOrder([100, 99, 98, 95]));
     });
 
-    test('.flatten()', () {
-      expect([].flatten(), []);
-
-      var list = [
-        [0, 0, 0],
-        [1, 1, 1],
-        [2, 2, 2],
-      ];
-
-      expect(list.flatten(), [0, 0, 0, 1, 1, 1, 2, 2, 2]);
-      expect(list.flatten(), isA<Iterable<int>>());
-      expect(list.flatten().toList(), isA<List<int>>());
-
-      var iterableOfIterables = Iterable.generate(3, (index) sync* {
-        yield index;
-        yield index + 1;
-        yield index + 2;
+    group('.flatten()', () {
+      test('for iterables of the same type', () {
+        // ignore: omit_local_variable_types
+        Iterable<Iterable<int>> iterableOfIterables =
+            Iterable.generate(3, (index) sync* {
+          yield index;
+          yield index + 1;
+          yield index + 2;
+        });
+        // ignore: omit_local_variable_types
+        Iterable<int> iterable = iterableOfIterables.flatten();
+        expect(iterable, [0, 1, 2, 1, 2, 3, 2, 3, 4]);
+        expect(iterable, isA<Iterable<int>>());
+        expect(iterable.toList(), isA<List<int>>());
       });
 
-      expect(iterableOfIterables.flatten(), [0, 1, 2, 1, 2, 3, 2, 3, 4]);
-      expect(iterableOfIterables.flatten(), isA<Iterable<int>>());
-      expect(iterableOfIterables.flatten().toList(), isA<List<int>>());
+      test('dynamic type', () {
+        // ignore: omit_local_variable_types
+        Iterable<Iterable<dynamic>> iterableOfIterables = () sync* {
+          yield [1, 2, 3];
+          yield ['a', 'b'];
+        }();
+        // ignore: omit_local_variable_types
+        Iterable<dynamic> iterable = iterableOfIterables.flatten();
+        expect(iterable, [1, 2, 3, 'a', 'b']);
+        expect(iterable, isA<Iterable<dynamic>>());
+      });
     });
 
     group('.cycle()', () {

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -620,9 +620,22 @@ void main() {
       var list = [
         [0, 0, 0],
         [1, 1, 1],
-        [2, 2, 2]
+        [2, 2, 2],
       ];
+
       expect(list.flatten(), [0, 0, 0, 1, 1, 1, 2, 2, 2]);
+      expect(list.flatten(), isA<Iterable<int>>());
+      expect(list.flatten().toList(), isA<List<int>>());
+
+      var iterableOfIterables = Iterable.generate(3, (index) sync* {
+        yield index;
+        yield index + 1;
+        yield index + 2;
+      });
+
+      expect(iterableOfIterables.flatten(), [0, 1, 2, 1, 2, 3, 2, 3, 4]);
+      expect(iterableOfIterables.flatten(), isA<Iterable<int>>());
+      expect(iterableOfIterables.flatten().toList(), isA<List<int>>());
     });
 
     group('.cycle()', () {

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -55,5 +55,18 @@ void main() {
       expect(list.dropLastWhile((it) => false), list);
       expect(list.dropLastWhile((it) => it > 3), [1, 2, 3]);
     });
+
+    test('.flatten()', () {
+      // ignore: omit_local_variable_types
+      List<List<int>> nestedList = [
+        [0, 0, 0],
+        [1, 1, 1],
+        [2, 2, 2],
+      ];
+
+      // ignore: omit_local_variable_types
+      List<int> flatten = nestedList.flatten();
+      expect(flatten, [0, 0, 0, 1, 1, 1, 2, 2, 2]);
+    });
   });
 }


### PR DESCRIPTION
Removes `Iterable<E>.flatten(): Iterable<dynamic>` in favor of
- `Iterable<Itearble<E>>.flatten(): Iterable<E>` and
- `List<List<E>>.flatten(): List<E>`

The old implementation wasn't type safe and risks a class cast exception

```dart
  Iterable<dynamic> flatten() sync* {
    for (var current in this) {
      yield* (current as Iterable); // cast may fail
    }
  }
```

I consider this change as almost-non-breaking 😁 
If `flatten()` was called on a non-nested `Iterable<E>` where `E` is not a `Iterable` it would fail at runtime. So the code was already broken.
The only exception is when `Iterable<dynamic>` is empty. For this code the method will not be available anymore.

This PR is a alternative to #55 