### PR TITLE
Add sliceWhen and chunkWhile

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ var nestedList = [[1, 2, 3], [4, 5, 6]];
 var flattened = nestedList.flatten(); // [1, 2, 3, 4, 5, 6]
 ```
 
+### .chunkWhile() & .splitWhen()
+
+Chunk entries as long as long as two elements match a predicate:
+```dart
+final list = [1, 2, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21];
+final increasingSubSequences = list.chunkWhile((a, b) => a + 1 == b);
+
+// increasingSubSequences = [[1, 2], [4], [9], [10, 11, 12], [15, 16], [19, 20, 21]]
+```
+
+`splitWhen` is the opposite of `chunkWhile` that starts a new chunk every time
+the predicate _didn't_ match.
+
 ## String
 
 ### .chars

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -727,15 +727,14 @@ extension IterableX<E> on Iterable<E> {
     for (final element in this) {
       if (!hasPrevious || predicate(previous, element)) {
         // keep element in current chunk
-        previous = element;
-        currentChunk.add(previous);
+        currentChunk.add(element);
       } else {
         // start a new chunk containing the new element
         yield currentChunk;
-        previous = element;
-        currentChunk = [previous];
+        currentChunk = [element];
       }
 
+      previous = element;
       hasPrevious = true;
     }
 

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -705,6 +705,61 @@ extension IterableX<E> on Iterable<E> {
     }
   }
 
+  /// Splits this collection into a lazy [Iterable] of chunks, where chunks are
+  /// created as long as [predicate] is true for a pair of entries.
+  ///
+  /// For example, one-by-one increasing subsequences can be chunked as follows:
+  /// ```dart
+  /// final list = [1, 2, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21];
+  /// final increasingSubSequences = list.chunkWhile((a, b) => a + 1 == b);
+  /// ```
+  ///
+  /// Here, `increasingSubSequences` would consist of `[1, 2]`, `[4]`,
+  /// `[9, 10, 11]`, `[12]`, `[15, 16]` and finally `[19, 20, 21]`.
+  ///
+  /// See also:
+  ///  - [splitWhen], which works similarly but with a reverted [predicate].
+  Iterable<List<E>> chunkWhile(bool Function(E, E) predicate) sync* {
+    var currentChunk = <E>[];
+    var hasPrevious = false;
+    /*late*/ E previous;
+
+    for (final element in this) {
+      if (!hasPrevious || predicate(previous, element)) {
+        // keep element in current chunk
+        previous = element;
+        currentChunk.add(previous);
+      } else {
+        // start a new chunk containing the new element
+        yield currentChunk;
+        previous = element;
+        currentChunk = [previous];
+      }
+
+      hasPrevious = true;
+    }
+
+    if (currentChunk.isNotEmpty) yield currentChunk;
+  }
+
+  /// Splits this collection into a lazy [Iterable], where each split will be
+  /// make if [predicate] returns true for a pair of entries.
+  ///
+  /// For example, one could split the iterable at each changed value like this:
+  /// ```dart
+  /// final list = [1, 1, 1, 2, 2, 1, 4, 4];
+  /// final splitted = list.splitWhen((a, b) => a != b);
+  /// ```
+  ///
+  /// In that example, `splitted` would consist of `[1, 1, 1, 1]`, `[2, 2]`,
+  /// `[1]`, `[4, 4]`.
+  ///
+  /// See also:
+  ///  - [chunkWhile], which works similarly but with a reverted [predicate].
+  Iterable<List<E>> splitWhen(bool Function(E, E) predicate) {
+    return chunkWhile((a, b) => !predicate(a, b));
+  }
+
   /// Returns a new lazy [Iterable] of windows of the given [size] sliding along
   /// this collection with the given [step].
   ///

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -548,6 +548,37 @@ void main() {
       expect(list.chunked(60), [list]);
     });
 
+    group('.chunkWhile()', () {
+      test('regular list', () {
+        var list = [1, 1, 1, 2, 2, 3, 4, 4];
+        expect(list.chunkWhile((a, b) => a == b), [
+          [1, 1, 1],
+          [2, 2],
+          [3],
+          [4, 4],
+        ]);
+      });
+
+      test('size 1', () {
+        expect(
+          [1].chunkWhile((a, b) => fail('Should not call predicate')),
+          [
+            [1]
+          ],
+        );
+      });
+    });
+
+    test('.splitWhen()', () {
+      var list = [1, 1, 1, 2, 2, 3, 4, 4];
+      expect(list.splitWhen((a, b) => a != b), [
+        [1, 1, 1],
+        [2, 2],
+        [3],
+        [4, 4],
+      ]);
+    });
+
     group('.windowed()', () {
       test('size 1', () {
         expect([].windowed(1), []);


### PR DESCRIPTION
These two operators can be used to dynamically split an iterable when two elements match a condition:
```dart
final list = [1, 2, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21];
final increasingSubSequences = list.chunkWhile((a, b) => a + 1 == b);
```

In general, grouping elements based on how an element relates to the next comes up quite often, so I think it can be a useful addition to this library.

Inspired from [`slice_when` and `chunk_while` in Crystal](https://github.com/crystal-lang/crystal/pull/7159).