### PR TITLE
Big ranges update

### DIFF
--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -38,12 +38,9 @@ extension ComparableX<T extends Comparable<T>> on T {
   /// Returns true if between [first] and [endInclusive].
   ///
   /// Equivalent to `ComparableRange(first, endInclusive).contains(this)`
-  ///
-  /// Uncomment this if it's useful for everyone
   bool between(T first, T endInclusive) =>
       first <= this && this <= endInclusive;
 
   /// Returns true if in the [range].
-  /// Uncomment this if it's useful for everyone
   bool inRange(ComparableRange<T> range) => range.contains(this);
 }

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -43,5 +43,5 @@ extension ComparableX<T extends Comparable<T>> on T {
       first.rangeTo(endInclusive).contains(this);
 
   /// Returns true if in the [range].
-  bool inRange(ClosedRange<T> range) => range.contains(this);
+  bool inRange(Range<T> range) => range.contains(this);
 }

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -27,26 +27,23 @@ extension ComparableX<T extends Comparable<T>> on T {
   ///
   /// @return this value if it's greater than or equal to the [minimumValue]
   /// or the [minimumValue] otherwise.
-  T coerceAtLeast(T minimumValue) =>
-      this < minimumValue ? minimumValue : this;
+  T coerceAtLeast(T minimumValue) => this < minimumValue ? minimumValue : this;
 
   /// Ensures that this value is not greater than the specified [maximumValue].
   ///
   /// @return this value if it's less than or equal to the [maximumValue]
   /// or the [maximumValue] otherwise.
-  T coerceAtMost(T maximumValue) =>
-      this > maximumValue ? maximumValue : this;
+  T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
 
   /// Returns true if between [first] and [endInclusive].
   ///
   /// Equivalent to `ComparableRange(first, endInclusive).contains(this)`
   ///
   /// Uncomment this if it's useful for everyone
-  //bool between(T first, T endInclusive) =>
-  //  first <= this && this <= endInclusive;
+  bool between(T first, T endInclusive) =>
+      first <= this && this <= endInclusive;
 
   /// Returns true if in the [range].
   /// Uncomment this if it's useful for everyone
-  //bool inRange(ComparableRange<T> range) => range.contains(this);
-
+  bool inRange(ComparableRange<T> range) => range.contains(this);
 }

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -42,5 +42,5 @@ extension ComparableX<T extends Comparable<T>> on T {
       first <= this && this <= endInclusive;
 
   /// Returns true if in the [range].
-  bool inRange(ComparableRange<T> range) => range.contains(this);
+  bool inRange(ClosedRange<T> range) => range.contains(this);
 }

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -36,4 +36,17 @@ extension ComparableX<T extends Comparable<T>> on T {
   /// or the [maximumValue] otherwise.
   T coerceAtMost(T maximumValue) =>
       this > maximumValue ? maximumValue : this;
+
+  /// Returns true if between [first] and [endInclusive].
+  ///
+  /// Equivalent to `ComparableRange(first, endInclusive).contains(this)`
+  ///
+  /// Uncomment this if it's useful for everyone
+  //bool between(T first, T endInclusive) =>
+  //  first <= this && this <= endInclusive;
+
+  /// Returns true if in the [range].
+  /// Uncomment this if it's useful for everyone
+  //bool inRange(ComparableRange<T> range) => range.contains(this);
+
 }

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -35,11 +35,12 @@ extension ComparableX<T extends Comparable<T>> on T {
   /// or the [maximumValue] otherwise.
   T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
 
-  /// Returns true if between [first] and [endInclusive].
+  /// Returns true when between [first] and [endInclusive]. The order of the
+  /// arguments doesn't matter.
   ///
-  /// Equivalent to `ComparableRange(first, endInclusive).contains(this)`
+  /// Alias for `first.rangeTo(endInclusive).contains(this)`
   bool between(T first, T endInclusive) =>
-      first <= this && this <= endInclusive;
+      first.rangeTo(endInclusive).contains(this);
 
   /// Returns true if in the [range].
   bool inRange(ClosedRange<T> range) => range.contains(this);

--- a/lib/src/num.dart
+++ b/lib/src/num.dart
@@ -45,12 +45,6 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtMost(20)) // 10
   /// ```
   T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
-
-  /// Returns true if between [first] and [endInclusive].
-  ///
-  /// Equivalent to `IntRange(first, endInclusive).contains(this)`
-  bool between(T first, T endInclusive) =>
-      first <= this && this <= endInclusive;
 }
 
 extension IntX<T extends int> on T {
@@ -63,6 +57,12 @@ extension IntX<T extends int> on T {
 
   /// Returns true if in the [range].
   bool inRange(IntRange range) => range.contains(this);
+
+  /// Returns true if between [first] and [endInclusive].
+  ///
+  /// Alias for `first.rangeTo(endInclusive).contains(this)`
+  bool between(int first, int endInclusive) =>
+      first.rangeTo(endInclusive).contains(this);
 }
 
 extension DoubleX<T extends double> on T {

--- a/lib/src/num.dart
+++ b/lib/src/num.dart
@@ -49,8 +49,6 @@ extension NumX<T extends num> on T {
   /// Returns true if between [first] and [endInclusive].
   ///
   /// Equivalent to `IntRange(first, endInclusive).contains(this)`
-  ///
-  /// Uncomment this if it's useful for everyone
   bool between(T first, T endInclusive) =>
       first <= this && this <= endInclusive;
 }
@@ -64,7 +62,6 @@ extension IntX<T extends int> on T {
   }
 
   /// Returns true if in the [range].
-  /// Uncomment this if it's useful for everyone
   bool inRange(IntRange range) => range.contains(this);
 }
 

--- a/lib/src/num.dart
+++ b/lib/src/num.dart
@@ -33,8 +33,7 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtLeast(5)) // 10
   /// print(10.coerceAtLeast(20)) // 20
   /// ```
-  T coerceAtLeast(T minimumValue) =>
-      this < minimumValue ? minimumValue : this;
+  T coerceAtLeast(T minimumValue) => this < minimumValue ? minimumValue : this;
 
   /// Ensures that this value is not greater than the specified [maximumValue].
   ///
@@ -45,8 +44,15 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtMost(5)) // 5
   /// print(10.coerceAtMost(20)) // 10
   /// ```
-  T coerceAtMost(T maximumValue) =>
-      this > maximumValue ? maximumValue : this;
+  T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
+
+  /// Returns true if between [first] and [endInclusive].
+  ///
+  /// Equivalent to `IntRange(first, endInclusive).contains(this)`
+  ///
+  /// Uncomment this if it's useful for everyone
+  bool between(T first, T endInclusive) =>
+      first <= this && this <= endInclusive;
 }
 
 extension IntX<T extends int> on T {
@@ -56,6 +62,10 @@ extension IntX<T extends int> on T {
     data.setInt64(0, this, endian);
     return data.buffer.asUint8List();
   }
+
+  /// Returns true if in the [range].
+  /// Uncomment this if it's useful for everyone
+  bool inRange(IntRange range) => range.contains(this);
 }
 
 extension DoubleX<T extends double> on T {

--- a/lib/src/num.dart
+++ b/lib/src/num.dart
@@ -45,6 +45,15 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtMost(20)) // 10
   /// ```
   T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
+
+  /// Returns true if in the [range].
+  bool inRange(Range<num> range) => range.contains(this);
+
+  /// Returns true if between [first] and [endInclusive].
+  ///
+  /// Alias for `first.rangeTo(endInclusive).contains(this)`
+  bool between(num first, num endInclusive) =>
+      first.rangeTo(endInclusive).contains(this);
 }
 
 extension IntX<T extends int> on T {
@@ -54,15 +63,6 @@ extension IntX<T extends int> on T {
     data.setInt64(0, this, endian);
     return data.buffer.asUint8List();
   }
-
-  /// Returns true if in the [range].
-  bool inRange(IntRange range) => range.contains(this);
-
-  /// Returns true if between [first] and [endInclusive].
-  ///
-  /// Alias for `first.rangeTo(endInclusive).contains(this)`
-  bool between(int first, int endInclusive) =>
-      first.rangeTo(endInclusive).contains(this);
 }
 
 extension DoubleX<T extends double> on T {

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -2,7 +2,7 @@ part of dartx;
 
 /// Represents a range of values (for example, numbers or characters)
 /// with a fixed [start] value and a fixed [endInclusive] value.
-abstract class ClosedRange<T extends Comparable<T>> {
+abstract class ClosedRange<T extends Comparable> {
   /// The first value in the range.
   T get start;
 
@@ -11,7 +11,13 @@ abstract class ClosedRange<T extends Comparable<T>> {
 
   /// Checks whether the specified [value] belongs to the range, is equal to
   /// [start] or [endInclusive] or lies between them
-  bool contains(T value);
+  bool contains(T value) {
+    if (start.compareTo(endInclusive) <= 0) {
+      return start.compareTo(value) <= 0 && value.compareTo(endInclusive) <= 0;
+    } else {
+      return endInclusive.compareTo(value) <= 0 && value.compareTo(start) <= 0;
+    }
+  }
 
   @override
   String toString() => '$start..$endInclusive';
@@ -29,47 +35,32 @@ abstract class ClosedRange<T extends Comparable<T>> {
 }
 
 /// Represents a range of [Comparable] values such as [String] or [DateTime]
-class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
+class _ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
   /// Create a range of [Comparable] values such as [String] or [DateTime]
   ///
-  /// The order of [first] and [endInclusive] doesn't matter.
-  ComparableRange(T first, T endInclusive)
-      : _first = first,
-        _last = endInclusive,
-        assert(() {
-          if (first == null) throw ArgumentError("start can't be null");
+  /// The order of [start] and [endInclusive] doesn't matter.
+  _ComparableRange(this.start, this.endInclusive)
+      : assert(() {
+          if (start == null) throw ArgumentError("start can't be null");
           if (endInclusive == null) {
             throw ArgumentError("endInclusive can't be null");
           }
           return true;
         }());
 
-  @override
-  T get start => _first;
-
   /// The first element in the range.
-  final T _first;
-
   @override
-  T get endInclusive => _last;
+  final T start;
 
   /// The last element in the range.
-  final T _last;
-
   @override
-  bool contains(T value) {
-    if (start <= endInclusive) {
-      return start <= value && value <= endInclusive;
-    } else {
-      return endInclusive <= value && value <= start;
-    }
-  }
+  final T endInclusive;
 }
 
 extension ComparableRangeX<T extends Comparable<T>> on T {
-  /// Creates a [ComparableRange] from this [Comparable] value
+  /// Creates a [ClosedRange] from this [Comparable] value
   /// to the specified [that] value.
-  ComparableRange<T> rangeTo(T that) => ComparableRange<T>(this, that);
+  ClosedRange<T> rangeTo(T that) => _ComparableRange<T>(this, that);
 }
 
 extension IntRangeExtension on int {
@@ -102,7 +93,7 @@ extension IntRangeExtension on int {
 /// size
 ///
 /// int doesn't extend Comparable<int>, uses ClosedRange<num> instead.
-class IntRange extends IterableBase<int> implements ClosedRange<num> {
+class IntRange extends IterableBase<int> implements ClosedRange<int> {
   /// Creates a range between two ints ([first], [endInclusive]) which can be
   /// iterated through.
   ///
@@ -152,16 +143,11 @@ class IntRange extends IterableBase<int> implements ClosedRange<num> {
 
   @override
   bool contains(Object element) {
-    if (element is! int) return false;
-    final value = element as int;
-    bool inRange;
-    if (start <= endInclusive) {
-      inRange = start <= value && value <= endInclusive;
-    } else {
-      inRange = endInclusive <= value && value <= start;
-    }
+    if (element is! num) return false;
+    final value = element as num;
+    final inRange = super.contains(value);
     if (!inRange) return false;
-    return _differenceModulo(value, start, stepSize) == 0;
+    return _differenceModulo(value.toInt(), start, stepSize) == 0;
   }
 
   @override

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -8,6 +8,8 @@ part of dartx;
 ///
 /// [ComparableRange] shows
 abstract class Range<T extends Comparable> {
+  const Range();
+
   /// The first value in the range.
   T get start;
 
@@ -104,8 +106,14 @@ extension DoubleRangeExtension on double {
 }
 
 class DoubleRange extends Range<double> {
-  DoubleRange(this.start, this.endInclusive);
-
+  DoubleRange(this.start, this.endInclusive)
+      : assert(() {
+          if (start == null) throw ArgumentError("start can't be null");
+          if (endInclusive == null) {
+            throw ArgumentError("endInclusive can't be null");
+          }
+          return true;
+        }());
   @override
   final double endInclusive;
 
@@ -147,19 +155,19 @@ class IntRange extends IntProgression implements Range<int> {
 
 class IntProgression extends IterableBase<int> {
   IntProgression(int first, int endInclusive, {int step = 1})
-      : _first = first,
-        // can't initialize directly du to naming conflict with step() method
-        // ignore: prefer_initializing_formals
-        stepSize = step,
-        _last = _getProgressionLastElement(first, endInclusive, step),
-        assert(() {
+      : assert(() {
           if (first == null) throw ArgumentError("start can't be null");
           if (endInclusive == null) {
             throw ArgumentError("endInclusive can't be null");
           }
           if (step == null) throw ArgumentError("step can't be null");
           return true;
-        }());
+        }()),
+        _first = first,
+        // can't initialize directly du to naming conflict with step() method
+        // ignore: prefer_initializing_formals
+        stepSize = step,
+        _last = _getProgressionLastElement(first, endInclusive, step);
 
   @override
   Iterator<int> get iterator => _IntRangeIterator(_first, _last, stepSize);
@@ -225,9 +233,8 @@ int _getProgressionLastElement(int start, int end, int step) {
   }
   if (start >= end) {
     return end;
-  } else {
-    return end - _differenceModulo(end, start, step);
   }
+  return end - _differenceModulo(end, start, step);
 }
 
 // (a - b) mod c
@@ -237,11 +244,7 @@ int _differenceModulo(int a, int b, int c) {
 
 int _mod(int a, int b) {
   final mod = a % b;
-  if (mod >= 0) {
-    return mod;
-  } else {
-    return mod + b;
-  }
+  return mod >= 0 ? mod : mod + b;
 }
 
 class _IntRangeIterator extends Iterator<int> {

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -151,6 +151,20 @@ class IntRange extends IterableBase<int> implements ClosedRange<num> {
   String toString() => '$start..$endInclusive';
 
   @override
+  bool contains(Object element) {
+    if (element is! int) return false;
+    final value = element as int;
+    bool inRange;
+    if (start <= endInclusive) {
+      inRange = start <= value && value <= endInclusive;
+    } else {
+      inRange = endInclusive <= value && value <= start;
+    }
+    if (!inRange) return false;
+    return _differenceModulo(value, start, stepSize) == 0;
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is IntRange &&

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -59,8 +59,9 @@ class _ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
 
 extension ComparableRangeX<T extends Comparable<T>> on T {
   /// Creates a [ClosedRange] from this [Comparable] value
-  /// to the specified [that] value.
-  ClosedRange<T> rangeTo(T that) => _ComparableRange<T>(this, that);
+  /// to the specified [endInclusive] value.
+  ClosedRange<T> rangeTo(T endInclusive) =>
+      _ComparableRange<T>(this, endInclusive);
 }
 
 extension IntRangeExtension on int {
@@ -91,8 +92,6 @@ extension IntRangeExtension on int {
 
 /// A iterable range between two ints which is iterable with a specific step
 /// size
-///
-/// int doesn't extend Comparable<int>, uses ClosedRange<num> instead.
 class IntRange extends IterableBase<int> implements ClosedRange<int> {
   /// Creates a range between two ints ([first], [endInclusive]) which can be
   /// iterated through.

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -3,10 +3,10 @@ part of dartx;
 /// Represents a range of values (for example, numbers or characters)
 /// with a fixed [start] value and a fixed [endInclusive] value.
 abstract class ClosedRange<T extends Comparable<T>> {
-  /// The minimum value in the range.
+  /// The first value in the range.
   T get start;
 
-  /// The maximum value in the range (inclusive).
+  /// The last value in the range (inclusive).
   T get endInclusive;
 
   /// Checks whether the specified [value] belongs to the range, is equal to
@@ -28,8 +28,11 @@ abstract class ClosedRange<T extends Comparable<T>> {
   int get hashCode => start.hashCode ^ endInclusive.hashCode;
 }
 
-/// Represents a range of [Comparable] values.
+/// Represents a range of [Comparable] values such as [String] or [DateTime]
 class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
+  /// Create a range of [Comparable] values such as [String] or [DateTime]
+  ///
+  /// The order of [first] and [endInclusive] doesn't matter.
   ComparableRange(T first, T endInclusive)
       : _first = first,
         _last = endInclusive,
@@ -41,8 +44,14 @@ class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
           return true;
         }());
 
+  @override
+  T get start => _first;
+
   /// The first element in the range.
   final T _first;
+
+  @override
+  T get endInclusive => _last;
 
   /// The last element in the range.
   final T _last;
@@ -55,12 +64,6 @@ class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
       return endInclusive <= value && value <= start;
     }
   }
-
-  @override
-  T get endInclusive => _last;
-
-  @override
-  T get start => _first;
 }
 
 extension ComparableRangeX<T extends Comparable<T>> on T {

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -1,5 +1,69 @@
 part of dartx;
 
+/// Represents a range of values (for example, numbers or characters).
+abstract class ClosedRange<T extends Comparable<T>> {
+  T get start;
+  T get endInclusive;
+
+  bool contains(T value);
+  bool get isEmpty;
+
+  @override
+  String toString() => '$start..$endInclusive';
+
+  @override
+  bool operator ==(Object other) =>
+    (other is ClosedRange) && (isEmpty && other.isEmpty ||
+     start == other.start && endInclusive == other.endInclusive);
+
+  @override
+  int get hashCode =>
+    isEmpty ? -1 : 31 * start.hashCode + endInclusive.hashCode;
+}
+
+/// Represents a range of [Comparable] values.
+class ComparableRange<T extends Comparable<T>> extends ClosedRange<T> {
+  ComparableRange(T first, T endInclusive)
+      : _first = first,
+        _last = endInclusive,
+        assert(() {
+          if (first == null) throw ArgumentError("start can't be null");
+          if (endInclusive == null) {
+            throw ArgumentError("endInclusive can't be null");
+          }
+          return true;
+        }());
+
+  /// The first element in the range.
+  final T _first;
+
+  /// The last element in the range.
+  final T _last;
+
+  @override
+  bool contains(T value) {
+    return start <= value && value <= endInclusive;
+  }
+
+  @override
+  T get endInclusive => _last;
+
+  @override
+  bool get isEmpty => !(start <= endInclusive);
+
+  @override
+  T get start => _first;
+
+}
+
+extension ComparableRangeX<T extends Comparable<T>> on T {
+  /// Creates a [ComparableRange] from this [Comparable] value
+  /// to the specified [that] value.
+  /// This value needs to be smaller than [that] value,
+  /// otherwise the returned range will be empty.
+  ComparableRange<T> rangeTo(T that) => ComparableRange<T>(this, that);
+}
+
 extension IntRangeExtension on int {
   /// Creates a [IntRange] with a step count of 1
   ///
@@ -28,7 +92,9 @@ extension IntRangeExtension on int {
 
 /// A iterable range between two ints which is iterable with a specific step
 /// size
-class IntRange extends IterableBase<int> {
+///
+/// int doesn't extend Comparable<int>, uses ClosedRange<num> instead.
+class IntRange extends IterableBase<int> implements ClosedRange<num> {
   /// Creates a range between two ints ([first], [endInclusive]) which can be
   /// iterated through.
   ///
@@ -60,6 +126,24 @@ class IntRange extends IterableBase<int> {
 
   @override
   Iterator<int> get iterator => _IntRangeIterator(_first, _last, stepSize);
+
+  @override
+  int get endInclusive => _last;
+
+  @override
+  int get start => _first;
+
+  @override
+  String toString() => '$start..$endInclusive';
+
+  @override
+  bool operator ==(Object other) =>
+    (other is ClosedRange) && (isEmpty && other.isEmpty ||
+     start == other.start && endInclusive == other.endInclusive);
+
+  @override
+  int get hashCode =>
+    isEmpty ? -1 : 31 * start.hashCode + endInclusive.hashCode;
 }
 
 extension IntRangeX on IntRange {

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -145,7 +145,12 @@ class IntRange extends IterableBase<int> implements ClosedRange<int> {
   bool contains(Object element) {
     if (element is! num) return false;
     final value = element as num;
-    final inRange = super.contains(value);
+    bool inRange;
+    if (start <= endInclusive) {
+      inRange = start <= value && value <= endInclusive;
+    } else {
+      inRange = endInclusive <= value && value <= start;
+    }
     if (!inRange) return false;
     return _differenceModulo(value.toInt(), start, stepSize) == 0;
   }

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -181,10 +181,8 @@ class IntProgression extends IterableBase<int> {
   /// The step of the range.
   final int stepSize;
 
-  @override
   int get endInclusive => _last;
 
-  @override
   int get start => _first;
 
   @override
@@ -197,6 +195,7 @@ class IntProgression extends IterableBase<int> {
   String toString() => '$start..$endInclusive';
 
   @override
+  // ignore: avoid_renaming_method_parameters
   bool contains(covariant int value) {
     bool inRange;
     if (start <= endInclusive) {
@@ -219,7 +218,6 @@ class IntProgression extends IterableBase<int> {
 
   @override
   int get hashCode => _first.hashCode ^ _last.hashCode ^ stepSize.hashCode;
-}
 
   /// Creates a [IntRange] with a different [stepSize],
   /// keeps first and last value

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -57,31 +57,20 @@ void main() {
     });
 
     test('.between()', () {
-      expect(
-          DateTime(1984, 11, 19)
-              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-          true);
-      expect(
-          DateTime(2019, 11, 19)
-              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-          true);
-      expect(
-          DateTime(2020, 1, 1)
-              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-          true);
-      expect(
-          DateTime(2020, 1, 2)
-              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-          false);
-      expect(
-          DateTime(1984, 11, 18)
-              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-          false);
+      var start = DateTime(1984, 11, 19);
+      var end = DateTime(2020, 01, 01);
+      expect(DateTime(1984, 11, 19).between(start, end), true);
+      expect(DateTime(2019, 11, 19).between(start, end), true);
+      expect(DateTime(2020, 01, 01).between(start, end), true);
+      expect(DateTime(2020, 01, 02).between(start, end), false);
+      expect(DateTime(1984, 11, 18).between(start, end), false);
     });
 
     test('.inRange()', () {
-      final range =
-          ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1));
+      final range = ComparableRange(
+        DateTime(1984, 11, 19),
+        DateTime(2020, 1, 1),
+      );
 
       expect(DateTime(1984, 11, 19).inRange(range), true);
       expect(DateTime(2019, 11, 19).inRange(range), true);

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -64,6 +64,13 @@ void main() {
       expect(DateTime(2020, 01, 01).between(start, end), true);
       expect(DateTime(2020, 01, 02).between(start, end), false);
       expect(DateTime(1984, 11, 18).between(start, end), false);
+
+      // reverse order
+      expect(DateTime(1984, 11, 19).between(end, start), true);
+      expect(DateTime(2019, 11, 19).between(end, start), true);
+      expect(DateTime(2020, 01, 01).between(end, start), true);
+      expect(DateTime(2020, 01, 02).between(end, start), false);
+      expect(DateTime(1984, 11, 18).between(end, start), false);
     });
 
     test('.inRange()', () {

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -49,6 +49,56 @@ void main() {
           DateTime(1984, 11, 1));
     });
 
+    //test('.between()', () {
+    //  expect(
+    //    DateTime(1984, 11, 19)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2019, 11, 19)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 1)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 2)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    false
+    //  );
+    //  expect(
+    //    DateTime(1984, 11, 18)
+    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+    //    false
+    //  );
+    //});
+
+    //test('.inRange()', () {
+    //  final range = ComparableRange(
+    //    DateTime(1984, 11, 19), DateTime(2020, 1, 1)
+    //  );
+
+    //  expect(
+    //    DateTime(1984, 11, 19).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2019, 11, 19).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 1).inRange(range), true
+    //  );
+    //  expect(
+    //    DateTime(2020, 1, 2).inRange(range), false
+    //  );
+    //  expect(
+    //    DateTime(1984, 11, 18).inRange(range), false
+    //  );
+    //});
+
     test('comparable extension operators', () {
       final one = _WrappedInt(1);
       final ten = _WrappedInt(10);

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -90,21 +90,6 @@ void main() {
       expect(DateTime(1984, 11, 18).inRange(range), false);
     });
 
-    test('.inRange() with step', () {
-      final range = 10.rangeTo(19).step(2);
-
-      expect(range.start, 10);
-      expect(range.endInclusive, 18);
-      expect(range.stepSize, 2);
-
-      expect(range.contains(10), isTrue);
-      expect(range.contains(11), isFalse);
-
-      expect(range.contains(18), isTrue);
-      expect(range.contains(19), isFalse);
-      expect(range.contains(20), isFalse);
-    });
-
     test('comparable extension operators', () {
       final one = _WrappedInt(1);
       final ten = _WrappedInt(10);

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -67,10 +67,7 @@ void main() {
     });
 
     test('.inRange()', () {
-      final range = ComparableRange(
-        DateTime(1984, 11, 19),
-        DateTime(2020, 1, 1),
-      );
+      final range = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
 
       expect(DateTime(1984, 11, 19).inRange(range), true);
       expect(DateTime(2019, 11, 19).inRange(range), true);

--- a/test/comparable_test.dart
+++ b/test/comparable_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:dartx/dartx.dart';
+import 'package:test/test.dart';
 
 class _WrappedInt implements Comparable<_WrappedInt> {
   final int value;
@@ -15,24 +15,31 @@ void main() {
     test('.coerceIn()', () {
       expect(DateTime(1984, 11, 19).coerceIn(DateTime(1984, 11, 1)),
           DateTime(1984, 11, 19));
-      expect(DateTime(1984, 11, 19).coerceIn(
-        DateTime(1984, 11, 1),
-        DateTime(1984, 11, 20),
-      ), DateTime(1984, 11, 19));
-      expect(DateTime(1984, 10, 28).coerceIn(
-        DateTime(1984, 11, 1),
-        DateTime(1984, 11, 20),
-      ), DateTime(1984, 11, 1));
-      expect(DateTime(1984, 12, 1).coerceIn(
-        DateTime(1984, 11, 1),
-        DateTime(1984, 11, 20),
-      ), DateTime(1984, 11, 20));
-      expect(() => 10.coerceIn(3, 2), throwsArgumentError);
-      expect(() =>
-          DateTime.now().coerceIn(
-            DateTime(1984, 11, 20),
+      expect(
+          DateTime(1984, 11, 19).coerceIn(
             DateTime(1984, 11, 1),
-          ), throwsArgumentError);
+            DateTime(1984, 11, 20),
+          ),
+          DateTime(1984, 11, 19));
+      expect(
+          DateTime(1984, 10, 28).coerceIn(
+            DateTime(1984, 11, 1),
+            DateTime(1984, 11, 20),
+          ),
+          DateTime(1984, 11, 1));
+      expect(
+          DateTime(1984, 12, 1).coerceIn(
+            DateTime(1984, 11, 1),
+            DateTime(1984, 11, 20),
+          ),
+          DateTime(1984, 11, 20));
+      expect(() => 10.coerceIn(3, 2), throwsArgumentError);
+      expect(
+          () => DateTime.now().coerceIn(
+                DateTime(1984, 11, 20),
+                DateTime(1984, 11, 1),
+              ),
+          throwsArgumentError);
     });
 
     test('.coerceAtLeast()', () {
@@ -49,55 +56,54 @@ void main() {
           DateTime(1984, 11, 1));
     });
 
-    //test('.between()', () {
-    //  expect(
-    //    DateTime(1984, 11, 19)
-    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-    //    true
-    //  );
-    //  expect(
-    //    DateTime(2019, 11, 19)
-    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-    //    true
-    //  );
-    //  expect(
-    //    DateTime(2020, 1, 1)
-    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-    //    true
-    //  );
-    //  expect(
-    //    DateTime(2020, 1, 2)
-    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-    //    false
-    //  );
-    //  expect(
-    //    DateTime(1984, 11, 18)
-    //      .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-    //    false
-    //  );
-    //});
+    test('.between()', () {
+      expect(
+          DateTime(1984, 11, 19)
+              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+          true);
+      expect(
+          DateTime(2019, 11, 19)
+              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+          true);
+      expect(
+          DateTime(2020, 1, 1)
+              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+          true);
+      expect(
+          DateTime(2020, 1, 2)
+              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+          false);
+      expect(
+          DateTime(1984, 11, 18)
+              .between(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+          false);
+    });
 
-    //test('.inRange()', () {
-    //  final range = ComparableRange(
-    //    DateTime(1984, 11, 19), DateTime(2020, 1, 1)
-    //  );
+    test('.inRange()', () {
+      final range =
+          ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1));
 
-    //  expect(
-    //    DateTime(1984, 11, 19).inRange(range), true
-    //  );
-    //  expect(
-    //    DateTime(2019, 11, 19).inRange(range), true
-    //  );
-    //  expect(
-    //    DateTime(2020, 1, 1).inRange(range), true
-    //  );
-    //  expect(
-    //    DateTime(2020, 1, 2).inRange(range), false
-    //  );
-    //  expect(
-    //    DateTime(1984, 11, 18).inRange(range), false
-    //  );
-    //});
+      expect(DateTime(1984, 11, 19).inRange(range), true);
+      expect(DateTime(2019, 11, 19).inRange(range), true);
+      expect(DateTime(2020, 1, 1).inRange(range), true);
+      expect(DateTime(2020, 1, 2).inRange(range), false);
+      expect(DateTime(1984, 11, 18).inRange(range), false);
+    });
+
+    test('.inRange() with step', () {
+      final range = 10.rangeTo(19).step(2);
+
+      expect(range.start, 10);
+      expect(range.endInclusive, 18);
+      expect(range.stepSize, 2);
+
+      expect(range.contains(10), isTrue);
+      expect(range.contains(11), isFalse);
+
+      expect(range.contains(18), isTrue);
+      expect(range.contains(19), isFalse);
+      expect(range.contains(20), isFalse);
+    });
 
     test('comparable extension operators', () {
       final one = _WrappedInt(1);

--- a/test/num_test.dart
+++ b/test/num_test.dart
@@ -23,27 +23,50 @@ void main() {
 
     test('.toBytes()', () {});
 
-    test('inRange()', () {
+    test('int.inRange()', () {
       expect(5.inRange(0.rangeTo(10)), isTrue);
-      expect(10.inRange(0.rangeTo(10)), isTrue);
+      expect(10.inRange(0.0.rangeTo(10.0)), isTrue);
       expect(0.inRange(0.rangeTo(10)), isTrue);
-      expect((-1).inRange(0.rangeTo(10)), isFalse);
+      expect((-1).inRange(0.0.rangeTo(10.0)), isFalse);
       expect(11.inRange(0.rangeTo(10)), isFalse);
     });
 
-    test('between()', () {
-      expect(5.between(0, 10), isTrue);
+    test('double.inRange()', () {
+      expect(5.0.inRange(0.rangeTo(10)), isTrue);
+      expect(10.0.inRange(0.0.rangeTo(10.0)), isTrue);
+      expect(0.0.inRange(0.rangeTo(10)), isTrue);
+      expect((-1.0).inRange(0.0.rangeTo(10.0)), isFalse);
+      expect(11.0.inRange(0.rangeTo(10)), isFalse);
+    });
+
+    test('int.between()', () {
+      expect(5.between(0.0, 10.0), isTrue);
       expect(10.between(0, 10), isTrue);
-      expect(0.between(0, 10), isTrue);
+      expect(0.between(0.0, 10.0), isTrue);
       expect((-1).between(0, 10), isFalse);
-      expect(11.between(0, 10), isFalse);
+      expect(11.between(0.0, 10.0), isFalse);
 
       // reverse order
       expect(5.between(10, 0), isTrue);
-      expect(10.between(10, 0), isTrue);
+      expect(10.between(10.0, 0.0), isTrue);
       expect(0.between(10, 0), isTrue);
-      expect((-1).between(10, 0), isFalse);
+      expect((-1).between(10.0, 0.0), isFalse);
       expect(11.between(10, 0), isFalse);
+    });
+
+    test('double.between()', () {
+      expect(5.0.between(0.0, 10.0), isTrue);
+      expect(10.0.between(0, 10), isTrue);
+      expect(0.0.between(0.0, 10.0), isTrue);
+      expect((-1.0).between(0, 10), isFalse);
+      expect(11.0.between(0.0, 10.0), isFalse);
+
+      // reverse order
+      expect(5.0.between(10, 0), isTrue);
+      expect(10.0.between(10.0, 0.0), isTrue);
+      expect(0.0.between(10, 0), isTrue);
+      expect((-1.0).between(10.0, 0.0), isFalse);
+      expect(11.0.between(10, 0), isFalse);
     });
   });
 }

--- a/test/num_test.dart
+++ b/test/num_test.dart
@@ -22,5 +22,28 @@ void main() {
     });
 
     test('.toBytes()', () {});
+
+    test('inRange()', () {
+      expect(5.inRange(0.rangeTo(10)), isTrue);
+      expect(10.inRange(0.rangeTo(10)), isTrue);
+      expect(0.inRange(0.rangeTo(10)), isTrue);
+      expect((-1).inRange(0.rangeTo(10)), isFalse);
+      expect(11.inRange(0.rangeTo(10)), isFalse);
+    });
+
+    test('between()', () {
+      expect(5.between(0, 10), isTrue);
+      expect(10.between(0, 10), isTrue);
+      expect(0.between(0, 10), isTrue);
+      expect((-1).between(0, 10), isFalse);
+      expect(11.between(0, 10), isFalse);
+
+      // reverse order
+      expect(5.between(10, 0), isTrue);
+      expect(10.between(10, 0), isTrue);
+      expect(0.between(10, 0), isTrue);
+      expect((-1).between(10, 0), isFalse);
+      expect(11.between(10, 0), isFalse);
+    });
   });
 }

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -9,31 +9,74 @@ void main() {
     test('downwards', () {
       expect(6.rangeTo(3).toList(), [6, 5, 4, 3]);
     });
-    test('empty when start == end', () {
-      expect(6.rangeTo(6).toList(), []);
+    test('never empty, at least emits the start value', () {
+      expect(6.rangeTo(6).toList(), [6]);
+    });
+
+    test('isEmpty always returns false', () {
+      expect(6.rangeTo(6).isEmpty, isFalse);
+      expect(6.rangeTo(1).isEmpty, isFalse);
+      expect(6.rangeTo(19).isEmpty, isFalse);
+      expect(0.rangeTo(0).isEmpty, isFalse);
+      expect(0.rangeTo(-1).isEmpty, isFalse);
+    });
+
+    test('isNotEmpty always returns true', () {
+      expect(6.rangeTo(6).isNotEmpty, isTrue);
+      expect(6.rangeTo(1).isNotEmpty, isTrue);
+      expect(6.rangeTo(19).isNotEmpty, isTrue);
+      expect(0.rangeTo(0).isNotEmpty, isTrue);
+      expect(0.rangeTo(-1).isNotEmpty, isTrue);
+    });
+
+    test('inverse range is not equal', () {
+      expect(3.rangeTo(9), isNot(9.rangeTo(3)));
     });
   });
 
   group('ClosedRange', () {
     test('==', () {
-      expect(
-        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)) ==
-        ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
-        isTrue
-      );
+      final r1 = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
+      final r2 = ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1));
+      expect(r1 == r2, isTrue);
 
-      final num zero = 0.0;
-      final num one = 1.0;
-      final numRange = zero.rangeTo(one);
-      // ComparableRange<num>.==(IntRange)
-      expect(0.rangeTo(1) == numRange, isTrue);
+      // ignore: omit_local_variable_types
+      final ComparableRange<num> comparableRange = ComparableRange(0, 1);
+      expect(ComparableRange<num>(0, 1), comparableRange);
+      expect(ComparableRange<num>(0, 1), comparableRange);
+
+      // ignore: omit_local_variable_types
+      final IntRange intRange = 0.rangeTo(1);
+      expect(IntRange(0, 1), intRange);
+
+      // not the same runtimeType
+      // ignore: unrelated_type_equality_checks
+      expect(comparableRange == intRange, isFalse);
+      // ignore: unrelated_type_equality_checks
+      expect(intRange == comparableRange, isFalse);
+    });
+
+    test('isEmpty always returns false', () {
+      var dateRange = DateTime(2020, 1, 1).rangeTo(DateTime(2020, 1, 1));
+      expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
+      expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
+      expect(dateRange.start, DateTime(2020, 1, 1));
+      expect(dateRange.endInclusive, DateTime(2020, 1, 1));
+    });
+
+    test("empty ranges aren't equal for unrelated types", () {
+      final intRange = 1.rangeTo(1);
+      expect(intRange.isEmpty, isFalse);
+      expect(intRange.first, 1);
+      expect(intRange.last, 1);
+      final dateRange = DateTime(2020, 1, 1).rangeTo(DateTime(2020, 1, 1));
+
+      expect(intRange, isNot(dateRange));
     });
 
     test('.toString', () {
-      expect(
-        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).toString(),
-        "1984-11-19 00:00:00.000..2020-01-01 00:00:00.000"
-      );
+      expect(DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).toString(),
+          '1984-11-19 00:00:00.000..2020-01-01 00:00:00.000');
       final num zero = 0;
       final num one = 1;
       final numRange = zero.rangeTo(one);
@@ -52,16 +95,6 @@ void main() {
       expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
       expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
       expect(dateRange.contains(DateTime(1984, 11, 18)), isFalse);
-    });
-    test('.isEmpty', () {
-      expect(
-        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).isEmpty,
-        false
-      );
-      expect(
-        DateTime(2020, 1, 1).rangeTo(DateTime(1984, 11, 19)).isEmpty,
-        isTrue
-      );
     });
   });
 
@@ -95,14 +128,66 @@ void main() {
     });
   });
 
-  group('IntRange contains', () {
-    test('contains', () {
+  group('IntRange', () {
+    group('last', () {
+      test(
+          'empty means first == endInclusive, '
+          'endInclusive and last are equivalent', () {
+        expect(IntRange(0, 0).last, 0);
+        expect(IntRange(0, 0).endInclusive, 0);
+        expect(IntRange(2, 2).last, 2);
+        expect(IntRange(2, 2).endInclusive, 2);
+        expect(IntRange(-4, -4).last, -4);
+        expect(IntRange(-4, -4).endInclusive, -4);
+      });
+      test('last returns the endInclusive value', () {
+        expect(IntRange(0, 10).last, 10);
+      });
+      test('step 2 returns the last value dividable by 2', () {
+        expect(IntRange(0, 9, step: 2).last, 8);
+      });
+
+      test('lastWhere', () {
+        final range = IntRange(0, 9, step: 3);
+        bool isEven(it) => it % 2 == 0;
+        expect(range.last, 9);
+        expect(range.lastWhere(isEven), 6);
+      });
+    });
+
+    group('first', () {
+      test('empty means first == endInclusive, start and first are equivalent',
+          () {
+        expect(IntRange(0, 0).first, 0);
+        expect(IntRange(0, 0).start, 0);
+        expect(IntRange(2, 2).first, 2);
+        expect(IntRange(2, 2).start, 2);
+        expect(IntRange(-4, -4).first, -4);
+        expect(IntRange(-4, -4).start, -4);
+      });
+      test('first returns the endInclusive value', () {
+        expect(IntRange(2, 10).first, 2);
+      });
+      test('step 2 returns the first value', () {
+        // step 2 doesn't mean first needs to be dividable by 2.
+        // It starts stepping at 2
+        expect(IntRange(1, 9, step: 2).first, 1);
+      });
+
+      test('firstWhere minds the predicate', () {
+        final range = IntRange(1, 10, step: 3);
+        bool isEven(it) => it % 2 == 0;
+        expect(range.first, 1);
+        expect(range.firstWhere(isEven), 4);
+      });
+    });
+    test('contains with step', () {
       expect(0.rangeTo(10).step(2).contains(1), isFalse);
       expect(0.rangeTo(10).step(2).contains(0), isTrue);
       expect(0.rangeTo(10).step(2).contains(10), isTrue);
     });
 
-    test('contains', () {
+    test('toString()', () {
       expect(0.rangeTo(1).toString(), '0..1');
     });
   });

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -121,11 +121,14 @@ void main() {
   group('IntRange properties', () {
     test('first', () {
       expect(3.rangeTo(7).first, 3);
+      expect(3.rangeTo(7).toIterable().first, 3);
     });
 
     test('last', () {
       expect(3.rangeTo(6).last, 6);
+      expect(3.rangeTo(6).toIterable().last, 6);
       expect(3.rangeTo(6).step(2).last, 5);
+      expect(3.rangeTo(6).step(2).toIterable().last, 5);
     });
 
     test('stepSize', () {
@@ -141,16 +144,21 @@ void main() {
           'endInclusive and last are equivalent', () {
         expect(IntRange(0, 0).last, 0);
         expect(IntRange(0, 0).endInclusive, 0);
+        expect(IntRange(0, 0).toIterable().last, 0);
         expect(IntRange(2, 2).last, 2);
         expect(IntRange(2, 2).endInclusive, 2);
+        expect(IntRange(2, 2).toIterable().last, 2);
         expect(IntRange(-4, -4).last, -4);
         expect(IntRange(-4, -4).endInclusive, -4);
+        expect(IntRange(-4, -4).toIterable().last, -4);
       });
       test('last returns the endInclusive value', () {
         expect(IntRange(0, 10).last, 10);
+        expect(IntRange(0, 10).toIterable().last, 10);
       });
       test('step 2 returns the last value dividable by 2', () {
         expect(IntRange(0, 9, step: 2).last, 8);
+        expect(IntRange(0, 9, step: 2).toIterable().last, 8);
       });
 
       test('lastWhere', () {
@@ -166,18 +174,23 @@ void main() {
           () {
         expect(IntRange(0, 0).first, 0);
         expect(IntRange(0, 0).start, 0);
+        expect(IntRange(0, 0).toIterable().first, 0);
         expect(IntRange(2, 2).first, 2);
         expect(IntRange(2, 2).start, 2);
+        expect(IntRange(2, 2).toIterable().first, 2);
         expect(IntRange(-4, -4).first, -4);
         expect(IntRange(-4, -4).start, -4);
+        expect(IntRange(-4, -4).toIterable().first, -4);
       });
       test('first returns the endInclusive value', () {
         expect(IntRange(2, 10).first, 2);
+        expect(IntRange(2, 10).toIterable().first, 2);
       });
       test('step 2 returns the first value', () {
         // step 2 doesn't mean first needs to be dividable by 2.
         // It starts stepping at 2
         expect(IntRange(1, 9, step: 2).first, 1);
+        expect(IntRange(1, 9, step: 2).toIterable().first, 1);
       });
 
       test('firstWhere minds the predicate', () {
@@ -188,18 +201,46 @@ void main() {
       });
     });
     test('contains with step', () {
-      final range = 10.rangeTo(19).step(2);
+      final range = 10.rangeTo(19).step(2); // [10, 12, 14, 16, 18]
 
       expect(range.start, 10);
       expect(range.endInclusive, 18);
       expect(range.stepSize, 2);
 
+      expect(range.contains(9), isFalse);
       expect(range.contains(10), isTrue);
       expect(range.contains(11), isFalse);
-
+      expect(range.contains(12), isTrue);
+      expect(range.contains(13), isFalse);
+      expect(range.contains(14), isTrue);
+      expect(range.contains(15), isFalse);
+      expect(range.contains(16), isTrue);
+      expect(range.contains(17), isFalse);
       expect(range.contains(18), isTrue);
       expect(range.contains(19), isFalse);
       expect(range.contains(20), isFalse);
+    });
+
+    test('contains with step downwards and negative', () {
+      final range = 2.rangeTo(-10).step(3); // [2, -1, -4, -7, -10]
+      expect(range.start, 2);
+      expect(range.endInclusive, -10);
+      expect(range.stepSize, 3);
+
+      expect(range.contains(3), isFalse);
+      expect(range.contains(2), isTrue);
+      expect(range.contains(0), isFalse);
+      expect(range.contains(-1), isTrue);
+      expect(range.contains(-2), isFalse);
+      expect(range.contains(-3), isFalse);
+      expect(range.contains(-4), isTrue);
+      expect(range.contains(-5), isFalse);
+      expect(range.contains(-6), isFalse);
+      expect(range.contains(-7), isTrue);
+      expect(range.contains(-8), isFalse);
+      expect(range.contains(-9), isFalse);
+      expect(range.contains(-10), isTrue);
+      expect(range.contains(-11), isFalse);
     });
 
     test('inRange()', () {

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -145,8 +145,15 @@ void main() {
     });
     test('alphabetical range', () {
       final alphabet = 'a'.rangeTo('z');
-      expect('d'.inRange(alphabet), isTrue);
-      expect('A'.inRange(alphabet), isFalse);
+      expect(alphabet.contains("a"), isTrue);
+      expect(alphabet.contains("b"), isTrue);
+      expect(alphabet.contains("y"), isTrue);
+      expect(alphabet.contains("z"), isTrue);
+
+      expect(alphabet.contains("A"), isFalse);
+      expect(alphabet.contains("B"), isFalse);
+      expect(alphabet.contains("Y"), isFalse);
+      expect(alphabet.contains("Z"), isFalse);
     });
   });
 

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -56,6 +56,12 @@ void main() {
       expect(intRange == comparableRange, isFalse);
     });
 
+    test('alphabetical range', () {
+      final alphabet = 'a'.rangeTo('z');
+      expect('d'.inRange(alphabet), isTrue);
+      expect('A'.inRange(alphabet), isFalse);
+    });
+
     test('isEmpty always returns false', () {
       var dateRange = DateTime(2020, 1, 1).rangeTo(DateTime(2020, 1, 1));
       expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
@@ -182,9 +188,34 @@ void main() {
       });
     });
     test('contains with step', () {
-      expect(0.rangeTo(10).step(2).contains(1), isFalse);
-      expect(0.rangeTo(10).step(2).contains(0), isTrue);
-      expect(0.rangeTo(10).step(2).contains(10), isTrue);
+      final range = 10.rangeTo(19).step(2);
+
+      expect(range.start, 10);
+      expect(range.endInclusive, 18);
+      expect(range.stepSize, 2);
+
+      expect(range.contains(10), isTrue);
+      expect(range.contains(11), isFalse);
+
+      expect(range.contains(18), isTrue);
+      expect(range.contains(19), isFalse);
+      expect(range.contains(20), isFalse);
+    });
+
+    test('inRange()', () {
+      expect(5.inRange(0.rangeTo(10)), isTrue);
+      expect(10.inRange(0.rangeTo(10)), isTrue);
+      expect(0.inRange(0.rangeTo(10)), isTrue);
+      expect((-1).inRange(0.rangeTo(10)), isFalse);
+      expect(11.inRange(0.rangeTo(10)), isFalse);
+    });
+
+    test('between()', () {
+      expect(5.between(0, 10), isTrue);
+      expect(10.between(0, 10), isTrue);
+      expect(0.between(0, 10), isTrue);
+      expect((-1).between(0, 10), isFalse);
+      expect(11.between(0, 10), isFalse);
     });
 
     test('toString()', () {

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -144,12 +144,12 @@ void main() {
         expect(IntRange(0, 10).toIterable().last, 10);
       });
       test('step 2 returns the last value dividable by 2', () {
-        expect(IntRange(0, 9, step: 2).last, 8);
-        expect(IntRange(0, 9, step: 2).toIterable().last, 8);
+        expect(IntProgression(0, 9, step: 2).last, 8);
+        expect(IntProgression(0, 9, step: 2).toIterable().last, 8);
       });
 
       test('lastWhere', () {
-        final range = IntRange(0, 9, step: 3);
+        final range = IntProgression(0, 9, step: 3);
         bool isEven(it) => it % 2 == 0;
         expect(range.last, 9);
         expect(range.lastWhere(isEven), 6);
@@ -176,27 +176,27 @@ void main() {
       test('step 2 returns the first value', () {
         // step 2 doesn't mean first needs to be dividable by 2.
         // It starts stepping at 2
-        expect(IntRange(1, 9, step: 2).first, 1);
-        expect(IntRange(1, 9, step: 2).toIterable().first, 1);
+        expect(IntProgression(1, 9, step: 2).first, 1);
+        expect(IntProgression(1, 9, step: 2).toIterable().first, 1);
       });
 
       test('firstWhere minds the predicate', () {
-        final range = IntRange(1, 10, step: 3);
+        final range = IntProgression(1, 10, step: 3);
         bool isEven(it) => it % 2 == 0;
         expect(range.first, 1);
         expect(range.firstWhere(isEven), 4);
       });
     });
     test('contains double', () {
-      final range = (2).rangeTo(-2);
+      final range = 2.rangeTo(-2);
       expect(range.contains(3.0), isFalse);
       expect(range.contains(2.9), isFalse);
       expect(range.contains(2.1), isFalse);
       expect(range.contains(2.0), isTrue);
       expect(range.contains(1.0), isTrue);
-      expect(range.contains(0.5), isFalse);
+      expect(range.contains(0.5), isTrue);
       expect(range.contains(0.0), isTrue);
-      expect(range.contains(-0.5), isFalse);
+      expect(range.contains(-0.5), isTrue);
       expect(range.contains(-1.0), isTrue);
       expect(range.contains(-2.0), isTrue);
       expect(range.contains(-2.1), isFalse);
@@ -211,59 +211,14 @@ void main() {
       expect(range.contains(-2.1), isFalse);
       expect(range.contains(-2.0), isTrue);
       expect(range.contains(-1.0), isTrue);
-      expect(range.contains(-0.5), isFalse);
+      expect(range.contains(-0.5), isTrue);
       expect(range.contains(0.0), isTrue);
-      expect(range.contains(0.5), isFalse);
+      expect(range.contains(0.5), isTrue);
       expect(range.contains(1.0), isTrue);
       expect(range.contains(2.0), isTrue);
       expect(range.contains(2.1), isFalse);
       expect(range.contains(2.9), isFalse);
       expect(range.contains(3.0), isFalse);
-    });
-
-    test('contains double with step', () {
-      final range = (-4).rangeTo(4).step(3); // [-4, -1, 2]
-      expect(range.contains(-5.0), isFalse);
-      expect(range.contains(-4.9), isFalse);
-      expect(range.contains(-4.1), isFalse);
-      expect(range.contains(-4.0), isTrue);
-      expect(range.contains(-3.9), isFalse);
-      expect(range.contains(-2.1), isFalse);
-      expect(range.contains(-2.0), isFalse);
-      expect(range.contains(-1.9), isFalse);
-      expect(range.contains(-1.0), isTrue);
-      expect(range.contains(-0.9), isFalse);
-      expect(range.contains(0.0), isFalse);
-      expect(range.contains(1.9), isFalse);
-      expect(range.contains(2.0), isTrue);
-      expect(range.contains(2.1), isFalse);
-      expect(range.contains(3.0), isFalse);
-      expect(range.contains(4.0), isFalse);
-      expect(range.contains(5.0), isFalse);
-    });
-
-    test('contains double with step downwards', () {
-      final range = (5).rangeTo(-4).step(3); // [5, 2, -1, -4]
-      expect(range.contains(6.0), isFalse);
-      expect(range.contains(5.1), isFalse);
-      expect(range.contains(5.0), isTrue);
-      expect(range.contains(4.9), isFalse);
-      expect(range.contains(2.1), isFalse);
-      expect(range.contains(2.0), isTrue);
-      expect(range.contains(1.9), isFalse);
-      expect(range.contains(0.9), isFalse);
-      expect(range.contains(0.0), isFalse);
-      expect(range.contains(-0.9), isFalse);
-      expect(range.contains(-1.0), isTrue);
-      expect(range.contains(-1.1), isFalse);
-      expect(range.contains(-1.9), isFalse);
-      expect(range.contains(-2.0), isFalse);
-      expect(range.contains(-2.1), isFalse);
-      expect(range.contains(-3.0), isFalse);
-      expect(range.contains(-3.9), isFalse);
-      expect(range.contains(-4.0), isTrue);
-      expect(range.contains(-5.1), isFalse);
-      expect(range.contains(-5.0), isFalse);
     });
 
     test('contains with step', () {
@@ -322,6 +277,13 @@ void main() {
       expect(0.between(0, 10), isTrue);
       expect((-1).between(0, 10), isFalse);
       expect(11.between(0, 10), isFalse);
+
+      // reverse order
+      expect(5.between(10, 0), isTrue);
+      expect(10.between(10, 0), isTrue);
+      expect(0.between(10, 0), isTrue);
+      expect((-1).between(10, 0), isFalse);
+      expect(11.between(10, 0), isFalse);
     });
 
     test('toString()', () {

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -2,6 +2,49 @@ import 'package:dartx/dartx.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('DoubleRangeExtension', () {
+    test('start', () {
+      expect(2.7.rangeTo(4.2).start, 2.7);
+      expect(2.7.rangeTo(4.2).start, isA<double>());
+    });
+    test('endInclusive', () {
+      expect(2.7.rangeTo(4.2).endInclusive, 4.2);
+      expect(2.7.rangeTo(4.2).endInclusive, isA<double>());
+    });
+    test('contains double (upwards)', () {
+      expect(2.7.rangeTo(4.2).contains(3.0), isTrue);
+      expect(2.7.rangeTo(4.2).contains(5.0), isFalse);
+    });
+    test('contains int (upwards)', () {
+      // compiler does the conversion from int to double
+      expect(2.7.rangeTo(4.2).contains(3), isTrue);
+      expect(2.7.rangeTo(4.2).contains(5), isFalse);
+
+      // makes sure contains accepts num
+      expect(2.7.rangeTo(4.2).contains(3.toInt()), isTrue);
+      expect(2.7.rangeTo(4.2).contains(5.toInt()), isFalse);
+    });
+    test('contains double (downwards)', () {
+      expect(4.2.rangeTo(2.7).contains(3.0), isTrue);
+      expect(4.2.rangeTo(2.7).contains(5.0), isFalse);
+    });
+    test('contains int (upwards)', () {
+      expect(4.2.rangeTo(2.7).contains(3), isTrue);
+      expect(4.2.rangeTo(2.7).contains(5), isFalse);
+    });
+    test('mix double and int', () {
+      expect(4.rangeTo(2), isA<IntRange>());
+      expect(4.2.rangeTo(2), isA<DoubleRange>());
+      expect(4.2.rangeTo(2.2), isA<DoubleRange>());
+
+      // This is impossible because dart doesn't support overrides
+      // expect(4.rangeTo(2.7), isA<DoubleRange>());
+    });
+    test('toString', () {
+      expect(4.2.rangeTo(2.7).contains(5), isFalse);
+    });
+  });
+
   group('rangeTo', () {
     test('upwards', () {
       expect(5.rangeTo(10).toList(), [5, 6, 7, 8, 9, 10]);

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -272,7 +272,6 @@ void main() {
       expect(range.start, 10);
       expect(range.endInclusive, 18);
       expect(range.stepSize, 2);
-
       expect(range.contains(9), isFalse);
       expect(range.contains(10), isTrue);
       expect(range.contains(11), isFalse);

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -145,15 +145,15 @@ void main() {
     });
     test('alphabetical range', () {
       final alphabet = 'a'.rangeTo('z');
-      expect(alphabet.contains("a"), isTrue);
-      expect(alphabet.contains("b"), isTrue);
-      expect(alphabet.contains("y"), isTrue);
-      expect(alphabet.contains("z"), isTrue);
+      expect(alphabet.contains('a'), isTrue);
+      expect(alphabet.contains('b'), isTrue);
+      expect(alphabet.contains('y'), isTrue);
+      expect(alphabet.contains('z'), isTrue);
 
-      expect(alphabet.contains("A"), isFalse);
-      expect(alphabet.contains("B"), isFalse);
-      expect(alphabet.contains("Y"), isFalse);
-      expect(alphabet.contains("Z"), isFalse);
+      expect(alphabet.contains('A'), isFalse);
+      expect(alphabet.contains('B'), isFalse);
+      expect(alphabet.contains('Y'), isFalse);
+      expect(alphabet.contains('Z'), isFalse);
     });
   });
 

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -2,7 +2,10 @@ import 'package:dartx/dartx.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('DoubleRangeExtension', () {
+  group('DoubleRange', () {
+    test('rangeTo with two doubles returns DoubleRange', () {
+      expect(4.2.rangeTo(2.2), isA<DoubleRange>());
+    });
     test('start', () {
       expect(2.7.rangeTo(4.2).start, 2.7);
       expect(2.7.rangeTo(4.2).start, isA<double>());
@@ -25,27 +28,197 @@ void main() {
       expect(2.7.rangeTo(4.2).contains(5.toInt()), isFalse);
     });
     test('contains double (downwards)', () {
-      expect(4.2.rangeTo(2.7).contains(3.0), isTrue);
-      expect(4.2.rangeTo(2.7).contains(5.0), isFalse);
+      expect(4.2.rangeTo(2.7).contains(3.1), isTrue);
+      expect(4.2.rangeTo(2.7).contains(5.1), isFalse);
     });
-    test('contains int (upwards)', () {
+    test('contains int (downwards)', () {
       expect(4.2.rangeTo(2.7).contains(3), isTrue);
       expect(4.2.rangeTo(2.7).contains(5), isFalse);
     });
-    test('mix double and int', () {
-      expect(4.rangeTo(2), isA<IntRange>());
+    test('mix with int returns DoubleRange', () {
       expect(4.2.rangeTo(2), isA<DoubleRange>());
-      expect(4.2.rangeTo(2.2), isA<DoubleRange>());
 
       // This is impossible because dart doesn't support overrides
       // expect(4.rangeTo(2.7), isA<DoubleRange>());
     });
     test('toString', () {
-      expect(4.2.rangeTo(2.7).contains(5), isFalse);
+      expect(4.2.rangeTo(2.7).toString(), '4.2..2.7');
+    });
+    test('hashcode equal no matter the order', () {
+      expect(4.2.rangeTo(2.7).hashCode, 2.7.rangeTo(4.2).hashCode);
+    });
+    test('equals same range', () {
+      expect(4.2.rangeTo(2.7), 4.2.rangeTo(2.7));
+    });
+    test('not equals when items swapped', () {
+      expect(4.2.rangeTo(2.7), isNot(2.7.rangeTo(4.2)));
+    });
+    test('start has to be non-null', () {
+      try {
+        DoubleRange(null, 1.0);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>()
+                .having((it) => it.message, 'message', 'start can\'t be null'));
+      }
+    });
+    test('endInclusive has to be non-null', () {
+      try {
+        DoubleRange(1.0, null);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>().having(
+                (it) => it.message, 'message', 'endInclusive can\'t be null'));
+      }
     });
   });
 
-  group('rangeTo', () {
+  group('ComparableRange', () {
+    test('start', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)).start, DateTime(1995));
+      expect(DateTime(1995).rangeTo(DateTime(2020)).start, isA<DateTime>());
+    });
+    test('endInclusive', () {
+      expect(
+          DateTime(1995).rangeTo(DateTime(2020)).endInclusive, DateTime(2020));
+      expect(
+          DateTime(1995).rangeTo(DateTime(2020)).endInclusive, isA<DateTime>());
+    });
+    test('contains (upwards)', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)).contains(DateTime(2016)),
+          isTrue);
+      expect(DateTime(1995).rangeTo(DateTime(2020)).contains(DateTime(1988)),
+          isFalse);
+    });
+    test('contains (downwards)', () {
+      expect(DateTime(2020).rangeTo(DateTime(1995)).contains(DateTime(2016)),
+          isTrue);
+      expect(DateTime(2020).rangeTo(DateTime(1995)).contains(DateTime(1988)),
+          isFalse);
+    });
+    test('rangeTo returns ComparableRange<DateTime>', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)),
+          isA<ComparableRange<DateTime>>());
+    });
+    test('hashcode equal no matter the order', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)).hashCode,
+          DateTime(2020).rangeTo(DateTime(1995)).hashCode);
+    });
+    test('equal', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)),
+          DateTime(1995).rangeTo(DateTime(2020)));
+      expect('a'.rangeTo('b'), 'a'.rangeTo('b'));
+    });
+    test('not equals when items swapped', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)),
+          isNot(DateTime(2020).rangeTo(DateTime(1995))));
+    });
+    test('toString', () {
+      expect(DateTime(1995).rangeTo(DateTime(2020)).toString(),
+          '1995-01-01 00:00:00.000..2020-01-01 00:00:00.000');
+    });
+    test('start has to be non-null', () {
+      try {
+        ComparableRange(null, DateTime(1));
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>()
+                .having((it) => it.message, 'message', 'start can\'t be null'));
+      }
+    });
+    test('endInclusive has to be non-null', () {
+      try {
+        ComparableRange(DateTime(1), null);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>().having(
+                (it) => it.message, 'message', 'endInclusive can\'t be null'));
+      }
+    });
+    test('alphabetical range', () {
+      final alphabet = 'a'.rangeTo('z');
+      expect('d'.inRange(alphabet), isTrue);
+      expect('A'.inRange(alphabet), isFalse);
+    });
+  });
+
+  group('IntRange', () {
+    test('start', () {
+      expect(12.rangeTo(17).start, 12);
+      expect(12.rangeTo(17).start, isA<int>());
+    });
+    test('endInclusive', () {
+      expect(12.rangeTo(17).endInclusive, 17);
+      expect(12.rangeTo(17).endInclusive, isA<int>());
+    });
+    test('contains double (upwards)', () {
+      expect(12.rangeTo(17).contains(13.1), isTrue);
+      expect(12.rangeTo(17).contains(18.1), isFalse);
+    });
+    test('contains int (upwards)', () {
+      // compiler does the conversion from int to double
+      expect(12.rangeTo(17).contains(13), isTrue);
+      expect(12.rangeTo(17).contains(18), isFalse);
+    });
+    test('contains double (downwards)', () {
+      expect(17.rangeTo(12).contains(13.1), isTrue);
+      expect(17.rangeTo(12).contains(18.1), isFalse);
+    });
+    test('contains int (downwards)', () {
+      expect(17.rangeTo(12).contains(13), isTrue);
+      expect(17.rangeTo(12).contains(18), isFalse);
+    });
+    test('rangeTo with two ints returns IntRange', () {
+      expect(17.rangeTo(12), isA<IntRange>());
+    });
+    test('hashcode equal no matter the order', () {
+      expect(12.rangeTo(17).hashCode, 17.rangeTo(12).hashCode);
+    });
+    test('not equals when items swapped', () {
+      expect(3.rangeTo(9), isNot(9.rangeTo(3)));
+    });
+    test('equal', () {
+      expect(3.rangeTo(9), 3.rangeTo(9));
+    });
+    test('toString', () {
+      expect(3.rangeTo(9).toString(), '3..9');
+    });
+    test('start has to be non-null', () {
+      try {
+        IntRange(null, 1);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>()
+                .having((it) => it.message, 'message', 'start can\'t be null'));
+      }
+    });
+    test('endInclusive has to be non-null', () {
+      try {
+        IntRange(1, null);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>().having(
+                (it) => it.message, 'message', 'endInclusive can\'t be null'));
+      }
+    });
+  });
+
+  group('IntProgression', () {
+    test('stepSize', () {
+      expect(5.rangeTo(10).step(2).stepSize, 2);
+    });
     test('upwards', () {
       expect(5.rangeTo(10).toList(), [5, 6, 7, 8, 9, 10]);
     });
@@ -55,7 +228,16 @@ void main() {
     test('never empty, at least emits the start value', () {
       expect(6.rangeTo(6).toList(), [6]);
     });
-
+    test('step upwards', () {
+      expect(5.rangeTo(10).step(2).toList(), [5, 7, 9]);
+    });
+    test('step downwards', () {
+      expect(6.rangeTo(3).step(2).toList(), [6, 4]);
+    });
+    test('step must be positive', () {
+      expect(() => 1.rangeTo(10).step(0), throwsA(isA<RangeError>()));
+      expect(() => 1.rangeTo(10).step(-2), throwsA(isA<RangeError>()));
+    });
     test('isEmpty always returns false', () {
       expect(6.rangeTo(6).isEmpty, isFalse);
       expect(6.rangeTo(1).isEmpty, isFalse);
@@ -63,7 +245,6 @@ void main() {
       expect(0.rangeTo(0).isEmpty, isFalse);
       expect(0.rangeTo(-1).isEmpty, isFalse);
     });
-
     test('isNotEmpty always returns true', () {
       expect(6.rangeTo(6).isNotEmpty, isTrue);
       expect(6.rangeTo(1).isNotEmpty, isTrue);
@@ -71,103 +252,116 @@ void main() {
       expect(0.rangeTo(0).isNotEmpty, isTrue);
       expect(0.rangeTo(-1).isNotEmpty, isTrue);
     });
-
-    test('inverse range is not equal', () {
-      expect(3.rangeTo(9), isNot(9.rangeTo(3)));
+    test('start has to be non-null', () {
+      try {
+        IntProgression(null, 1);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>()
+                .having((it) => it.message, 'message', 'start can\'t be null'));
+      }
     });
-  });
-
-  group('ClosedRange', () {
-    test('==', () {
-      final r1 = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
-      final r2 = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
-      expect(r1 == r2, isTrue);
-
-      expect('a'.rangeTo('b'), 'a'.rangeTo('b'));
+    test('endInclusive has to be non-null', () {
+      try {
+        IntProgression(1, null);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>().having(
+                (it) => it.message, 'message', 'endInclusive can\'t be null'));
+      }
     });
-
-    test('alphabetical range', () {
-      final alphabet = 'a'.rangeTo('z');
-      expect('d'.inRange(alphabet), isTrue);
-      expect('A'.inRange(alphabet), isFalse);
+    test('endInclusive has to be non-null', () {
+      try {
+        IntProgression(1, 2, step: null);
+        fail('did not throw');
+      } catch (e) {
+        expect(
+            e,
+            isA<ArgumentError>()
+                .having((it) => it.message, 'message', 'step can\'t be null'));
+      }
     });
+    group('contains', () {
+      test('contains double', () {
+        final range = 2.rangeTo(-2);
+        expect(range.contains(3.0), isFalse);
+        expect(range.contains(2.9), isFalse);
+        expect(range.contains(2.1), isFalse);
+        expect(range.contains(2.0), isTrue);
+        expect(range.contains(1.0), isTrue);
+        expect(range.contains(0.5), isTrue);
+        expect(range.contains(0.0), isTrue);
+        expect(range.contains(-0.5), isTrue);
+        expect(range.contains(-1.0), isTrue);
+        expect(range.contains(-2.0), isTrue);
+        expect(range.contains(-2.1), isFalse);
+        expect(range.contains(-2.9), isFalse);
+        expect(range.contains(-3.0), isFalse);
+      });
 
-    test('isEmpty always returns false', () {
-      var dateRange = DateTime(2020, 1, 1).rangeTo(DateTime(2020, 1, 1));
-      expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
-      expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
-      expect(dateRange.start, DateTime(2020, 1, 1));
-      expect(dateRange.endInclusive, DateTime(2020, 1, 1));
+      test('contains double downwards', () {
+        final range = (-2).rangeTo(2);
+        expect(range.contains(-3.0), isFalse);
+        expect(range.contains(-2.9), isFalse);
+        expect(range.contains(-2.1), isFalse);
+        expect(range.contains(-2.0), isTrue);
+        expect(range.contains(-1.0), isTrue);
+        expect(range.contains(-0.5), isTrue);
+        expect(range.contains(0.0), isTrue);
+        expect(range.contains(0.5), isTrue);
+        expect(range.contains(1.0), isTrue);
+        expect(range.contains(2.0), isTrue);
+        expect(range.contains(2.1), isFalse);
+        expect(range.contains(2.9), isFalse);
+        expect(range.contains(3.0), isFalse);
+      });
+
+      test('contains with step', () {
+        final range = 10.rangeTo(19).step(2); // [10, 12, 14, 16, 18]
+
+        expect(range.start, 10);
+        expect(range.endInclusive, 18);
+        expect(range.stepSize, 2);
+        expect(range.contains(9), isFalse);
+        expect(range.contains(10), isTrue);
+        expect(range.contains(11), isFalse);
+        expect(range.contains(12), isTrue);
+        expect(range.contains(13), isFalse);
+        expect(range.contains(14), isTrue);
+        expect(range.contains(15), isFalse);
+        expect(range.contains(16), isTrue);
+        expect(range.contains(17), isFalse);
+        expect(range.contains(18), isTrue);
+        expect(range.contains(19), isFalse);
+        expect(range.contains(20), isFalse);
+      });
+
+      test('contains with step downwards and negative', () {
+        final range = 2.rangeTo(-10).step(3); // [2, -1, -4, -7, -10]
+        expect(range.start, 2);
+        expect(range.endInclusive, -10);
+        expect(range.stepSize, 3);
+
+        expect(range.contains(3), isFalse);
+        expect(range.contains(2), isTrue);
+        expect(range.contains(0), isFalse);
+        expect(range.contains(-1), isTrue);
+        expect(range.contains(-2), isFalse);
+        expect(range.contains(-3), isFalse);
+        expect(range.contains(-4), isTrue);
+        expect(range.contains(-5), isFalse);
+        expect(range.contains(-6), isFalse);
+        expect(range.contains(-7), isTrue);
+        expect(range.contains(-8), isFalse);
+        expect(range.contains(-9), isFalse);
+        expect(range.contains(-10), isTrue);
+        expect(range.contains(-11), isFalse);
+      });
     });
-
-    test("empty ranges aren't equal for unrelated types", () {
-      final intRange = 1.rangeTo(1);
-      expect(intRange.isEmpty, isFalse);
-      expect(intRange.first, 1);
-      expect(intRange.last, 1);
-      final dateRange = DateTime(2020, 1, 1).rangeTo(DateTime(2020, 1, 1));
-
-      expect(intRange, isNot(dateRange));
-    });
-
-    test('.toString', () {
-      expect(DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).toString(),
-          '1984-11-19 00:00:00.000..2020-01-01 00:00:00.000');
-      final num zero = 0;
-      final num one = 1;
-      final numRange = zero.rangeTo(one);
-      expect(numRange.toString(), '0..1');
-      final num zeroDouble = 0.0;
-      final num oneDouble = 1.0;
-      expect(zeroDouble.rangeTo(oneDouble).toString(), '0.0..1.0');
-    });
-  });
-
-  group('ComparableRange', () {
-    test('.contains()', () {
-      final dateRange = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
-      expect(dateRange.contains(DateTime(1984, 11, 19)), isTrue);
-      expect(dateRange.contains(DateTime(2019, 11, 19)), isTrue);
-      expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
-      expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
-      expect(dateRange.contains(DateTime(1984, 11, 18)), isFalse);
-    });
-  });
-
-  group('rangeTo with step()', () {
-    test('upwards', () {
-      expect(5.rangeTo(10).step(2).toList(), [5, 7, 9]);
-    });
-    test('downwards', () {
-      expect(6.rangeTo(3).step(2).toList(), [6, 4]);
-    });
-
-    test('step must be positive', () {
-      expect(() => 1.rangeTo(10).step(0), throwsA(isA<RangeError>()));
-      expect(() => 1.rangeTo(10).step(-2), throwsA(isA<RangeError>()));
-    });
-  });
-
-  group('IntRange properties', () {
-    test('first', () {
-      expect(3.rangeTo(7).first, 3);
-      expect(3.rangeTo(7).toIterable().first, 3);
-    });
-
-    test('last', () {
-      expect(3.rangeTo(6).last, 6);
-      expect(3.rangeTo(6).toIterable().last, 6);
-      expect(3.rangeTo(6).step(2).last, 5);
-      expect(3.rangeTo(6).step(2).toIterable().last, 5);
-    });
-
-    test('stepSize', () {
-      expect(3.rangeTo(6).stepSize, 1);
-      expect(3.rangeTo(6).step(2).stepSize, 2);
-    });
-  });
-
-  group('IntRange', () {
     group('last', () {
       test(
           'empty means first == endInclusive, '
@@ -190,7 +384,6 @@ void main() {
         expect(IntProgression(0, 9, step: 2).last, 8);
         expect(IntProgression(0, 9, step: 2).toIterable().last, 8);
       });
-
       test('lastWhere', () {
         final range = IntProgression(0, 9, step: 3);
         bool isEven(it) => it % 2 == 0;
@@ -222,115 +415,12 @@ void main() {
         expect(IntProgression(1, 9, step: 2).first, 1);
         expect(IntProgression(1, 9, step: 2).toIterable().first, 1);
       });
-
       test('firstWhere minds the predicate', () {
         final range = IntProgression(1, 10, step: 3);
         bool isEven(it) => it % 2 == 0;
         expect(range.first, 1);
         expect(range.firstWhere(isEven), 4);
       });
-    });
-    test('contains double', () {
-      final range = 2.rangeTo(-2);
-      expect(range.contains(3.0), isFalse);
-      expect(range.contains(2.9), isFalse);
-      expect(range.contains(2.1), isFalse);
-      expect(range.contains(2.0), isTrue);
-      expect(range.contains(1.0), isTrue);
-      expect(range.contains(0.5), isTrue);
-      expect(range.contains(0.0), isTrue);
-      expect(range.contains(-0.5), isTrue);
-      expect(range.contains(-1.0), isTrue);
-      expect(range.contains(-2.0), isTrue);
-      expect(range.contains(-2.1), isFalse);
-      expect(range.contains(-2.9), isFalse);
-      expect(range.contains(-3.0), isFalse);
-    });
-
-    test('contains double downwards', () {
-      final range = (-2).rangeTo(2);
-      expect(range.contains(-3.0), isFalse);
-      expect(range.contains(-2.9), isFalse);
-      expect(range.contains(-2.1), isFalse);
-      expect(range.contains(-2.0), isTrue);
-      expect(range.contains(-1.0), isTrue);
-      expect(range.contains(-0.5), isTrue);
-      expect(range.contains(0.0), isTrue);
-      expect(range.contains(0.5), isTrue);
-      expect(range.contains(1.0), isTrue);
-      expect(range.contains(2.0), isTrue);
-      expect(range.contains(2.1), isFalse);
-      expect(range.contains(2.9), isFalse);
-      expect(range.contains(3.0), isFalse);
-    });
-
-    test('contains with step', () {
-      final range = 10.rangeTo(19).step(2); // [10, 12, 14, 16, 18]
-
-      expect(range.start, 10);
-      expect(range.endInclusive, 18);
-      expect(range.stepSize, 2);
-      expect(range.contains(9), isFalse);
-      expect(range.contains(10), isTrue);
-      expect(range.contains(11), isFalse);
-      expect(range.contains(12), isTrue);
-      expect(range.contains(13), isFalse);
-      expect(range.contains(14), isTrue);
-      expect(range.contains(15), isFalse);
-      expect(range.contains(16), isTrue);
-      expect(range.contains(17), isFalse);
-      expect(range.contains(18), isTrue);
-      expect(range.contains(19), isFalse);
-      expect(range.contains(20), isFalse);
-    });
-
-    test('contains with step downwards and negative', () {
-      final range = 2.rangeTo(-10).step(3); // [2, -1, -4, -7, -10]
-      expect(range.start, 2);
-      expect(range.endInclusive, -10);
-      expect(range.stepSize, 3);
-
-      expect(range.contains(3), isFalse);
-      expect(range.contains(2), isTrue);
-      expect(range.contains(0), isFalse);
-      expect(range.contains(-1), isTrue);
-      expect(range.contains(-2), isFalse);
-      expect(range.contains(-3), isFalse);
-      expect(range.contains(-4), isTrue);
-      expect(range.contains(-5), isFalse);
-      expect(range.contains(-6), isFalse);
-      expect(range.contains(-7), isTrue);
-      expect(range.contains(-8), isFalse);
-      expect(range.contains(-9), isFalse);
-      expect(range.contains(-10), isTrue);
-      expect(range.contains(-11), isFalse);
-    });
-
-    test('inRange()', () {
-      expect(5.inRange(0.rangeTo(10)), isTrue);
-      expect(10.inRange(0.rangeTo(10)), isTrue);
-      expect(0.inRange(0.rangeTo(10)), isTrue);
-      expect((-1).inRange(0.rangeTo(10)), isFalse);
-      expect(11.inRange(0.rangeTo(10)), isFalse);
-    });
-
-    test('between()', () {
-      expect(5.between(0, 10), isTrue);
-      expect(10.between(0, 10), isTrue);
-      expect(0.between(0, 10), isTrue);
-      expect((-1).between(0, 10), isFalse);
-      expect(11.between(0, 10), isFalse);
-
-      // reverse order
-      expect(5.between(10, 0), isTrue);
-      expect(10.between(10, 0), isTrue);
-      expect(0.between(10, 0), isTrue);
-      expect((-1).between(10, 0), isFalse);
-      expect(11.between(10, 0), isFalse);
-    });
-
-    test('toString()', () {
-      expect(0.rangeTo(1).toString(), '0..1');
     });
   });
 }

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -37,23 +37,10 @@ void main() {
   group('ClosedRange', () {
     test('==', () {
       final r1 = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
-      final r2 = ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1));
+      final r2 = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
       expect(r1 == r2, isTrue);
 
-      // ignore: omit_local_variable_types
-      final ComparableRange<num> comparableRange = ComparableRange(0, 1);
-      expect(ComparableRange<num>(0, 1), comparableRange);
-      expect(ComparableRange<num>(0, 1), comparableRange);
-
-      // ignore: omit_local_variable_types
-      final IntRange intRange = 0.rangeTo(1);
-      expect(IntRange(0, 1), intRange);
-
-      // not the same runtimeType
-      // ignore: unrelated_type_equality_checks
-      expect(comparableRange == intRange, isFalse);
-      // ignore: unrelated_type_equality_checks
-      expect(intRange == comparableRange, isFalse);
+      expect('a'.rangeTo('b'), 'a'.rangeTo('b'));
     });
 
     test('alphabetical range', () {
@@ -200,6 +187,85 @@ void main() {
         expect(range.firstWhere(isEven), 4);
       });
     });
+    test('contains double', () {
+      final range = (2).rangeTo(-2);
+      expect(range.contains(3.0), isFalse);
+      expect(range.contains(2.9), isFalse);
+      expect(range.contains(2.1), isFalse);
+      expect(range.contains(2.0), isTrue);
+      expect(range.contains(1.0), isTrue);
+      expect(range.contains(0.5), isFalse);
+      expect(range.contains(0.0), isTrue);
+      expect(range.contains(-0.5), isFalse);
+      expect(range.contains(-1.0), isTrue);
+      expect(range.contains(-2.0), isTrue);
+      expect(range.contains(-2.1), isFalse);
+      expect(range.contains(-2.9), isFalse);
+      expect(range.contains(-3.0), isFalse);
+    });
+
+    test('contains double downwards', () {
+      final range = (-2).rangeTo(2);
+      expect(range.contains(-3.0), isFalse);
+      expect(range.contains(-2.9), isFalse);
+      expect(range.contains(-2.1), isFalse);
+      expect(range.contains(-2.0), isTrue);
+      expect(range.contains(-1.0), isTrue);
+      expect(range.contains(-0.5), isFalse);
+      expect(range.contains(0.0), isTrue);
+      expect(range.contains(0.5), isFalse);
+      expect(range.contains(1.0), isTrue);
+      expect(range.contains(2.0), isTrue);
+      expect(range.contains(2.1), isFalse);
+      expect(range.contains(2.9), isFalse);
+      expect(range.contains(3.0), isFalse);
+    });
+
+    test('contains double with step', () {
+      final range = (-4).rangeTo(4).step(3); // [-4, -1, 2]
+      expect(range.contains(-5.0), isFalse);
+      expect(range.contains(-4.9), isFalse);
+      expect(range.contains(-4.1), isFalse);
+      expect(range.contains(-4.0), isTrue);
+      expect(range.contains(-3.9), isFalse);
+      expect(range.contains(-2.1), isFalse);
+      expect(range.contains(-2.0), isFalse);
+      expect(range.contains(-1.9), isFalse);
+      expect(range.contains(-1.0), isTrue);
+      expect(range.contains(-0.9), isFalse);
+      expect(range.contains(0.0), isFalse);
+      expect(range.contains(1.9), isFalse);
+      expect(range.contains(2.0), isTrue);
+      expect(range.contains(2.1), isFalse);
+      expect(range.contains(3.0), isFalse);
+      expect(range.contains(4.0), isFalse);
+      expect(range.contains(5.0), isFalse);
+    });
+
+    test('contains double with step downwards', () {
+      final range = (5).rangeTo(-4).step(3); // [5, 2, -1, -4]
+      expect(range.contains(6.0), isFalse);
+      expect(range.contains(5.1), isFalse);
+      expect(range.contains(5.0), isTrue);
+      expect(range.contains(4.9), isFalse);
+      expect(range.contains(2.1), isFalse);
+      expect(range.contains(2.0), isTrue);
+      expect(range.contains(1.9), isFalse);
+      expect(range.contains(0.9), isFalse);
+      expect(range.contains(0.0), isFalse);
+      expect(range.contains(-0.9), isFalse);
+      expect(range.contains(-1.0), isTrue);
+      expect(range.contains(-1.1), isFalse);
+      expect(range.contains(-1.9), isFalse);
+      expect(range.contains(-2.0), isFalse);
+      expect(range.contains(-2.1), isFalse);
+      expect(range.contains(-3.0), isFalse);
+      expect(range.contains(-3.9), isFalse);
+      expect(range.contains(-4.0), isTrue);
+      expect(range.contains(-5.1), isFalse);
+      expect(range.contains(-5.0), isFalse);
+    });
+
     test('contains with step', () {
       final range = 10.rangeTo(19).step(2); // [10, 12, 14, 16, 18]
 

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -14,6 +14,57 @@ void main() {
     });
   });
 
+  group('ClosedRange', () {
+    test('==', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)) ==
+        ComparableRange(DateTime(1984, 11, 19), DateTime(2020, 1, 1)),
+        isTrue
+      );
+
+      final num zero = 0.0;
+      final num one = 1.0;
+      final numRange = zero.rangeTo(one);
+      // ComparableRange<num>.==(IntRange)
+      expect(0.rangeTo(1) == numRange, isTrue);
+    });
+
+    test('.toString', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).toString(),
+        "1984-11-19 00:00:00.000..2020-01-01 00:00:00.000"
+      );
+      final num zero = 0;
+      final num one = 1;
+      final numRange = zero.rangeTo(one);
+      expect(numRange.toString(), '0..1');
+      final num zeroDouble = 0.0;
+      final num oneDouble = 1.0;
+      expect(zeroDouble.rangeTo(oneDouble).toString(), '0.0..1.0');
+    });
+  });
+
+  group('ComparableRange', () {
+    test('.contains()', () {
+      final dateRange = DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1));
+      expect(dateRange.contains(DateTime(1984, 11, 19)), isTrue);
+      expect(dateRange.contains(DateTime(2019, 11, 19)), isTrue);
+      expect(dateRange.contains(DateTime(2020, 1, 1)), isTrue);
+      expect(dateRange.contains(DateTime(2020, 1, 2)), isFalse);
+      expect(dateRange.contains(DateTime(1984, 11, 18)), isFalse);
+    });
+    test('.isEmpty', () {
+      expect(
+        DateTime(1984, 11, 19).rangeTo(DateTime(2020, 1, 1)).isEmpty,
+        false
+      );
+      expect(
+        DateTime(2020, 1, 1).rangeTo(DateTime(1984, 11, 19)).isEmpty,
+        isTrue
+      );
+    });
+  });
+
   group('rangeTo with step()', () {
     test('upwards', () {
       expect(5.rangeTo(10).step(2).toList(), [5, 7, 9]);
@@ -49,6 +100,10 @@ void main() {
       expect(0.rangeTo(10).step(2).contains(1), isFalse);
       expect(0.rangeTo(10).step(2).contains(0), isTrue);
       expect(0.rangeTo(10).step(2).contains(10), isTrue);
+    });
+
+    test('contains', () {
+      expect(0.rangeTo(1).toString(), '0..1');
     });
   });
 }


### PR DESCRIPTION
Drastically improves the handling of ranges (`1.rangeTo(10)`) and expands support from `int` ranges to other types. Now ranges between `int`, `double` and `Comparable` (i.e. `DateTime` or `String`) are possible.

This PR builds upon work in #45 

## Progressions

Further I made a distinction between ranges and progressions.

### Range
A Range (`ComparableRange`, `IntRange`, `DoubleRange`) describes two values (`start` and `endInclusive`) which allows checking if a third value is within that range (`Range.contains(other)`).

### Progression

A `Progression` is a range which allows iterating over its values (`Iterable`). An `IntRange` extends `IntProgression` and allows iterating over the values with a `stepSize` (default `1`).

When a `Range` doesn't extend `Progression` it's not possible to iterate over the values.

## Difference to Kotlins ranges

The major difference between ranges in Kotlin and dartx is that our progression don't require a different function when the starting value is bigger than the end value.


```kotlin
//kotlin
0..10 // range from 0 to 10
10..0 // empty range from 10 to 10
10 downTo 0 // range from 0 to 10
```

```dart
// dartx
0.rangeTo(10) // range from 0 to 10
10.rangeTo(0) // range from 10 to 0
```

This also has consequences on the `isEmpty` property of a progression (which implements `Iterable`). `dartx` progressions are never empty, they always contain the start and end value (which might be the same).

## API changes

### `IntRange`

`int.rangeTo(int end): IntRange` (unchanged)

- extends `IntProgression` (new)
- `isEmpty` now always returns `false`
- `toList()` returns a list containing at least start and end value.

### New: `DoubleRange`

`double.rangeTo(double end): DoubleRange`

### New: `ComparableRange<T>`

`Comparable<T>.rangeTo(Comparable<T> end): ComparableRange`

Commonly used for `DateTime` and `String`

### Convenience extensions:

Reverse to `Range.contains` on can ask the value if it is between two values or within a Range.

#### between
- `num.between(num first, num endInclusive): bool`
- `Comparable<T>.between(T first, T endInclusive): bool`

#### inRange
- `Comparable<T>.inRange(ComparableRange<T> range): bool`
- `num.inRange(Range<num> range): bool`

## Code samples
```dart
// test data
final killerQueen = DateTime(1974, 10, 21);
final bohemianRhapsody = DateTime(1975, 10, 31);
final underPressure = DateTime(1981, 10, 26);
final theShowMustGoOn_US_Release = DateTime(1992, 02, 06);
final freddieMercuryLifeSpan = DateTime(1946, 09, 5).rangeTo(DateTime(1991, 11, 24));
final vietnamWar = DateTime(1955, 11, 1).rangeTo(DateTime(1975, 04, 30));
```

```dart
// ComparableRange.contains
print(freddieMercuryLifeSpan.contains(bohemianRhapsody)); // true
print(freddieMercuryLifeSpan.contains(theShowMustGoOn_US_Release)); // false
```

```dart
// Comparable.between
print(bohemianRhapsody.between(killerQueen, underPressure)); // true
print(bohemianRhapsody.between(underPressure, killerQueen)); // true
print(theShowMustGoOn_US_Release.between(bohemianRhapsody, underPressure)); // false
```

```dart
// Comparable.inRange
print(killerQueen.inRange(freddieMercuryLifeSpan)); // true
print(bohemianRhapsody.inRange(vietnamWar)); // false
```

```dart
// IntRange
5.rangeTo(10).forEach(print); // 5, 6, 7, 8, 9, 10
(5.rangeTo(10)).contains(8); // true, lies between start and endInclusive
(5.rangeTo(10)).contains(11); // false
(5.rangeTo(10)).contains(7.5); // true, doubles are possible
```

```dart
// IntProgression
5.rangeTo(10).step(2).forEach(print); // 5, 7, 9
5.rangeTo(10).step(2).contains(7); // true
5.rangeTo(10).step(2).contains(6); // false, not a value from progression
// 5.rangeTo(10).step(2).contains(4.4); // doesn't accept doubles!
```