### PR TITLE
Run tests on macOS

### DIFF
--- a/.github/workflows/dartx.yml
+++ b/.github/workflows/dartx.yml
@@ -16,6 +16,20 @@ jobs:
       - name: Run tests
         run: C:\tools\dart-sdk\bin\pub.bat run test
 
+  test-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tap Google's Dart formula repository
+        run: brew tap dart-lang/dart
+      - name: Install the Dart formula
+        run: brew install dart
+      - name: Install dependencies
+        run: pub get
+      - name: Run tests
+        run: pub run test
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Sorry for the other closed pull requests, I enabled the actions on my fork to make sure that the new `test-macos` job passes.