### PR TITLE
Increase path range

### DIFF
--- a/.github/workflows/dartx.yml
+++ b/.github/workflows/dartx.yml
@@ -3,7 +3,26 @@ name: Dart CI
 on: [push, pull_request]
 
 jobs:
+  test:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        version: ["2.6", "2.7", "2.8", "dev"]
+
+    container:
+      image:  google/dart:${{ matrix.version }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: pub get
+      - name: Run tests
+        run: pub run test
+
   test-windows:
+    timeout-minutes: 5
     runs-on: windows-latest
 
     steps:
@@ -17,6 +36,7 @@ jobs:
         run: C:\tools\dart-sdk\bin\pub.bat run test
 
   test-macos:
+    timeout-minutes: 5
     runs-on: macos-latest
 
     steps:
@@ -30,20 +50,8 @@ jobs:
       - name: Run tests
         run: pub run test
 
-  test:
-    runs-on: ubuntu-latest
-
-    container:
-      image:  google/dart:dev
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: pub get
-      - name: Run tests
-        run: pub run test
-
   format:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     container:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ">=1.14.11 <1.15.0"
-  path: ^1.7.0
+  path: ^1.6.2
   crypto: ">=2.1.0 <2.2.0"
   characters: ">=0.4.0 <1.0.0"
   time: ^1.2.0

--- a/test/file_system_entity.dart
+++ b/test/file_system_entity.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:dartx/dartx_io.dart';
+
+void main() {
+  group('FileSystemEntity', () {
+    test('name', () {
+      final file = File('~/home/log.txt');
+      expect(file.name, 'log.txt');
+    });
+    test('nameWithoutExtension', () {
+      final file = File('~/home/log.txt');
+      expect(file.name, 'log');
+    });
+    test('dirName', () {
+      final file = File('~/home/log.txt');
+      expect(file.dirName, '~/home');
+    });
+    test('isWithin', () {
+      final file = File('~/home/log.txt');
+      final home = Directory('~/home/');
+      expect(file.isWithin(home), isTrue);
+    });
+    test('withName', () {
+      final file = File('~/home/log.txt');
+      expect(file.withName('text.log'), File('~/home/text.log'));
+    });
+    test('extension', () {
+      final file = File('~/home/log.txt');
+      expect(file.extension, '.txt');
+    });
+  });
+}


### PR DESCRIPTION
I checked `path` again and can verify the [`context.extension`](https://pub.dev/documentation/path/latest/path/Context/extension.html) method was already added in `1.6.2`. It's therefore possible to increase the range.

I verified it working by adding tests and then explicitly use `1.6.2` as dependency.

fixes #77
fixes #78 