### PR TITLE
added list.swap()

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -153,6 +153,18 @@ extension ListX<E> on List<E> {
   void mergeSort({int start = 0, int end, Comparator<E> comparator}) {
     _mergeSort(this, start: start, end: end, compare: comparator);
   }
+
+  /// Swaps the elements in the indices provided.
+  ///
+  /// ```dart
+  /// var list = [1, 2, 3, 4];
+  /// list.swap(0, 2); // [3, 2, 1, 4]
+  /// ```
+  void swap(int i, int j) {
+    final temp = this[i];
+    this[i] = this[j];
+    this[j] = temp;
+  }
 }
 
 extension ListListX<E> on List<List<E>> {

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -60,6 +60,7 @@ void main() {
       var list = [1, 2, 3, 4, 5];
       expect(list..swap(0, 0), [1, 2, 3, 4, 5]);
       expect(list..swap(1, 2), [1, 3, 2, 4, 5]);
+      expect(() => list.swap(3, 9), throwsA(isA<RangeError>()));
     });
 
     test('.flatten()', () {

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -56,6 +56,12 @@ void main() {
       expect(list.dropLastWhile((it) => it > 3), [1, 2, 3]);
     });
 
+    test('.swap()', () {
+      var list = [1, 2, 3, 4, 5];
+      expect(list..swap(0, 0), [1, 2, 3, 4, 5]);
+      expect(list..swap(1, 2), [1, 3, 2, 4, 5]);
+    });
+
     test('.flatten()', () {
       // ignore: omit_local_variable_types
       List<List<int>> nestedList = [


### PR DESCRIPTION
It's quite useful to swap two elements in a list. For example in flutter's `ReorderableListView`. Here's a very simple implementation of it.