### PR TITLE
Fix #91 make .zip() work for different types

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -948,6 +948,17 @@ extension IterableX<E> on Iterable<E> {
   ///
   /// Using the provided [transform] function applied to each pair of elements.
   /// The returned list has length of the shortest collection.
+  ///
+  /// Example (with added type definitions for [transform] parameters):
+  ///
+  /// ```dart
+  ///final amounts = [2, 3, 4];
+  ///final animals = ['dogs', 'birds', 'cats'];
+  ///final all = amounts.zip(
+  ///  animals,
+  ///  (int amount, String animal) => '$amount $animal'
+  ///);  // returns: ['2 dogs', '3 birds', '4 cats']
+  /// ```
   Iterable<V> zip<R, V>(
     Iterable<R> other,
     V Function(E a, R b) transform,

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -948,9 +948,12 @@ extension IterableX<E> on Iterable<E> {
   ///
   /// Using the provided [transform] function applied to each pair of elements.
   /// The returned list has length of the shortest collection.
-  Iterable<R> zip<R>(Iterable<E> other, R transform(E a, E b)) sync* {
-    var it1 = iterator;
-    var it2 = other.iterator;
+  Iterable<V> zip<R, V>(
+    Iterable<R> other,
+    V Function(E a, R b) transform,
+  ) sync* {
+    final it1 = iterator;
+    final it2 = other.iterator;
     while (it1.moveNext() && it2.moveNext()) {
       yield transform(it1.current, it2.current);
     }

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -794,10 +794,16 @@ void main() {
     });
 
     group('.zip()', () {
-      test('with same types and same length', () {
+      test('with same types', () {
         expect([].zip([], (e1, e2) => null), []);
-        expect([1, 2, 3].zip([2, 4, 6], (e1, e2) => e1 / e2), [0.5, 0.5, 0.5]);
-        expect([2, 4, 6].zip([1, 2, 3], (e1, e2) => e1 / e2), [2.0, 2.0, 2.0]);
+        expect(
+          [1, 2, 3].zip([2, 4, 6], (e1, int e2) => e1 / e2),
+          [0.5, 0.5, 0.5],
+        );
+        expect(
+          [2, 4, 6].zip([1, 2, 3], (e1, int e2) => e1 / e2),
+          [2.0, 2.0, 2.0],
+        );
 
         // with type definitions
         expect(
@@ -807,8 +813,26 @@ void main() {
       });
 
       test('with same types and different length', () {
-        expect([1, 2, 3].zip([2, 4], (e1, e2) => e1 / e2), [0.5, 0.5]);
-        expect([2, 4].zip([2, 2, 2], (e1, e2) => e1 / e2), [1.0, 2.0]);
+        expect([1, 2, 3].zip([2, 4], (e1, int e2) => e1 / e2), [0.5, 0.5]);
+        expect([2, 4].zip([2, 2, 2], (e1, int e2) => e1 / e2), [1.0, 2.0]);
+      });
+
+      test('with different types', () {
+        final amounts = [2, 3, 4];
+        final animals = ['dogs', 'birds', 'cats'];
+        expect(
+          amounts.zip(animals, (amount, String animal) => '$amount $animal'),
+          ['2 dogs', '3 birds', '4 cats'],
+        );
+      });
+
+      test('with different types and different lengths', () {
+        final amounts = [2, 3];
+        final animals = ['dogs', 'birds', 'cats'];
+        expect(
+          amounts.zip(animals, (amount, String animal) => '$amount $animal'),
+          ['2 dogs', '3 birds'],
+        );
       });
     });
 

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -793,10 +793,23 @@ void main() {
       expect([3, 4, 5].union([4, 10, 20]), [3, 4, 5, 10, 20]);
     });
 
-    test('.zip()', () {
-      expect([].zip([], (e1, e2) => null), []);
-      expect([1, 2, 3].zip([2, 4, 6], (e1, e2) => e1 / e2), [0.5, 0.5, 0.5]);
-      expect([2, 4, 6].zip([1, 2, 3], (e1, e2) => e1 / e2), [2.0, 2.0, 2.0]);
+    group('.zip()', () {
+      test('with same types and same length', () {
+        expect([].zip([], (e1, e2) => null), []);
+        expect([1, 2, 3].zip([2, 4, 6], (e1, e2) => e1 / e2), [0.5, 0.5, 0.5]);
+        expect([2, 4, 6].zip([1, 2, 3], (e1, e2) => e1 / e2), [2.0, 2.0, 2.0]);
+
+        // with type definitions
+        expect(
+          [1, 2, 3].zip([2, 4, 6], (int e1, int e2) => e1 / e2),
+          [0.5, 0.5, 0.5],
+        );
+      });
+
+      test('with same types and different length', () {
+        expect([1, 2, 3].zip([2, 4], (e1, e2) => e1 / e2), [0.5, 0.5]);
+        expect([2, 4].zip([2, 2, 2], (e1, e2) => e1 / e2), [1.0, 2.0]);
+      });
     });
 
     test('.toIterable()', () {


### PR DESCRIPTION
This is only here for the discussion in #91 - please don't merge (yet).