### PR TITLE
Add run configuration for all tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@
 *.iml
 *.ipr
 *.iws
-.idea/
+.idea/*
+!.idea/runConfigurations
 
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line

--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="filePath" value="$PROJECT_DIR$" />
+    <option name="scope" value="FOLDER" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
A very simple change, which adds a 'All Tests' run config option for all developers who want to contribute to dartx (and use IntelliJ):

![image](https://user-images.githubusercontent.com/400322/86497651-c5ca7780-bd82-11ea-96cf-837e1dac17f4.png)
