### PR TITLE
Reactivate codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,4 +19,4 @@ jobs:
           pub global run test_coverage
       - uses: codecov/codecov-action@v1
         with:
-          file: dartx/coverage/lcov.info
+          file: coverage/lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,6 @@ jobs:
         run: |
           pub global activate test_coverage
           pub global run test_coverage
-      - uses: codecov/codecov-action@v1.0.0
+      - uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: dartx/coverage/lcov.info


### PR DESCRIPTION
Removes the token. Codecov works without it for public repos

Fixes #92 