### PR TITLE
Add .get() to Iterable

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -25,6 +25,28 @@ extension IterableX<E> on Iterable<E> {
   /// ```
   E get fourth => elementAt(3);
 
+  /// Returns the element at the given [index].
+  /// 
+  /// ```dart
+  /// var list = [1, 2, 3, 4];
+  /// var first = list.get(0); // 1
+  /// ```
+  /// 
+  /// Support negative indexing.
+  /// 
+  /// ```dart
+  /// var list = [1, 2, 3, 4];
+  /// var last = list.get(-1); // 4
+  /// var thirdLast = list.get(-3); // 2
+  /// ```
+  E get(int index) {
+    var positiveIndex = index;
+    if (index < 0) {
+      positiveIndex = length + index;
+    }
+    return elementAt(positiveIndex);
+  }
+
   /// Returns an element at the given [index] or `null` if the [index] is out of
   /// bounds of this collection.
   ///

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -38,6 +38,28 @@ void main() {
       });
     });
 
+    test('.get()', () {
+      expect([1, 2, 3].get(0), 1);
+      expect([1, 2, 3].get(1), 2);
+      expect([1, 2, 3].get(2), 3);
+      try {
+        [1, 2, 3].get(4);
+        fail('Expected RangeError');
+      } catch (e) {
+        expect(e.runtimeType, RangeError);
+      }
+
+      expect([1, 2, 3].get(-1), 3);
+      expect([1, 2, 3].get(-2), 2);
+      expect([1, 2, 3].get(-3), 1);
+      try {
+        [1, 2, 3].get(-4);
+        fail('Expected RangeError');
+      } catch (e) {
+        expect(e.runtimeType, RangeError);
+      }
+    });
+
     test('.elementAtOrNull()', () {
       expect([1, 2, 3].elementAtOrNull(-1), null);
       expect([1, 2, 3].elementAtOrNull(0), 1);


### PR DESCRIPTION
Added the method `.get()` to `Iterable`. Similar to [Java's `List.get()`](https://docs.oracle.com/javase/8/docs/api/java/util/List.html#get-int-). 

Additionally the method supports negative indexing. This means that the nth element is returned from behind. For example:

```dart
var list = [1, 2, 3, 4];
var last = list.get(-1); // 4
var thirdLast = list.get(-3); // 2
```