### PR TITLE
update test package to latest version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   meta: ^1.1.6
 
 dev_dependencies:
-  test: ^1.15.7
+  test: ^1.13.0
   pedantic: ^1.8.0
   fake_async: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   meta: ^1.1.6
 
 dev_dependencies:
-  test: ^1.9.2
+  test: ^1.15.7
   pedantic: ^1.8.0
   fake_async: ^1.1.0


### PR DESCRIPTION
Try to fix [failing](https://github.com/leisim/dartx/pull/113) [tests](https://github.com/leisim/dartx/pull/109) by updating to latest test package because that package depends on the analyzer package which seems to cause the failing tests:

```
/github/home/.pub-cache/hosted/pub.dartlang.org/analyzer-0.39.15/lib/src/dart/resolver/extension_member_resolver.dart:355:38: Error: The getter 'extensions' isn't defined for the class 'Scope'.
 - 'Scope' is from 'package:analyzer/dart/element/scope.dart' ('/github/home/.pub-cache/hosted/pub.dartlang.org/analyzer-0.39.15/lib/dart/element/scope.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'extensions'.
    for (var extension in _nameScope.extensions) {
                                     ^^^^^^^^^^
```