### PR TITLE
Feature/update dart sdks

### DIFF
--- a/.github/workflows/dartx.yml
+++ b/.github/workflows/dartx.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        version: ["2.6", "2.7", "2.8", "dev"]
+        version: ["2.7", "2.8", "2.9", "2.10", "dev"]
 
     container:
       image:  google/dart:${{ matrix.version }}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.5.0
 homepage: https://github.com/leisim/dartx
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   collection: ^1.14.11


### PR DESCRIPTION
Now [three](https://github.com/leisim/dartx/pull/103) [Pull](https://github.com/leisim/dartx/pull/109) [Requests](https://github.com/leisim/dartx/pull/113) failed because of an outdated analyzer package (v0.39.15) of Dart 2.6. Maybe, Dart  2.6 support should be ended and instead, tests should also run for Dart 2.9 and 2.10. 