### PR TITLE
Issue #57. Implement .slice() on string

### DIFF
--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -189,7 +189,7 @@ extension StringX on String {
   /// Returns a new substring containing all characters between [start]
   /// (inclusive) and [end] (inclusive).
   /// If [end] is omitted, it is being set to `lastIndex`.
-  /// 
+  ///
   ///  ```dart
   /// print('awesomeString'.slice(0,6)); // awesome
   /// print('awesomeString'.slice(7)); // String

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -185,4 +185,21 @@ extension StringX on String {
       return this;
     }
   }
+
+  /// Returns a new substring containing all characters between [start]
+  /// (inclusive) and [end] (inclusive).
+  /// If [end] is omitted, it is being set to `lastIndex`.
+  /// 
+  ///  ```dart
+  /// print('awesomeString'.slice(0,6)); // awesome
+  /// print('awesomeString'.slice(7)); // String
+  /// ```
+  String slice(int start, [int end = -1]) {
+    start = start < 0 ? start + length : start;
+    end = end < 0 ? end + length : end;
+
+    RangeError.checkValidRange(start, end, length);
+
+    return substring(start, end + 1);
+  }
 }

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -197,19 +197,19 @@ void main() {
       );
     });
 
-    test('.slice()', (){
-      expect('awesomeString'.slice(0,6), 'awesome');
-      expect('awesomeString'.slice(0,-7), 'awesome');
+    test('.slice()', () {
+      expect('awesomeString'.slice(0, 6), 'awesome');
+      expect('awesomeString'.slice(0, -7), 'awesome');
       expect('awesomeString'.slice(7), 'String');
       expect('awesomeString'.slice(-6), 'String');
       expect('awesomeString'.slice(-6, -1), 'String');
-      expect('awesomeString'.slice(-6,8), 'St');
+      expect('awesomeString'.slice(-6, 8), 'St');
       expect('awesomeString'.slice(0), 'awesomeString');
-      
+
       expect(() => ''.slice(0), throwsRangeError);
-      expect(() => ''.slice(0,1), throwsRangeError);
+      expect(() => ''.slice(0, 1), throwsRangeError);
       expect(() => ''.slice(-1), throwsRangeError);
-      expect(() => ''.slice(0,-1), throwsRangeError);
+      expect(() => ''.slice(0, -1), throwsRangeError);
       expect(() => 'awesomeString'.slice(1, 13), throwsRangeError);
       expect(() => 'awesomeString'.slice(2, 1), throwsRangeError);
       expect(() => 'awesomeString'.slice(13), throwsRangeError);

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -196,5 +196,25 @@ void main() {
         same(expected),
       );
     });
+
+    test('.slice()', (){
+      expect('awesomeString'.slice(0,6), 'awesome');
+      expect('awesomeString'.slice(0,-7), 'awesome');
+      expect('awesomeString'.slice(7), 'String');
+      expect('awesomeString'.slice(-6), 'String');
+      expect('awesomeString'.slice(-6, -1), 'String');
+      expect('awesomeString'.slice(-6,8), 'St');
+      expect('awesomeString'.slice(0), 'awesomeString');
+      
+      expect(() => ''.slice(0), throwsRangeError);
+      expect(() => ''.slice(0,1), throwsRangeError);
+      expect(() => ''.slice(-1), throwsRangeError);
+      expect(() => ''.slice(0,-1), throwsRangeError);
+      expect(() => 'awesomeString'.slice(1, 13), throwsRangeError);
+      expect(() => 'awesomeString'.slice(2, 1), throwsRangeError);
+      expect(() => 'awesomeString'.slice(13), throwsRangeError);
+      expect(() => 'awesomeString'.slice(-14), throwsRangeError);
+      expect(() => 'awesomeString'.slice(-1, -2), throwsRangeError);
+    });
   });
 }


### PR DESCRIPTION
This pr implements the .slice() extension for strings, mentioned in #57. The behaviour is the same like on the slice extension on the iterable.