### PR TITLE
Add `.indexIntervals()`, `.mode()`, `.variance()`, and `.stdDev()` methods.

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -433,7 +433,7 @@ extension IterableX<E> on Iterable<E> {
   /// Returns a list containing first [n] elements.
   ///
   /// ```dart
-  /// val chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  /// var chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   /// print(chars.take(3)) // [1, 2, 3]
   /// print(chars.takeWhile((it) => it < 5) // [1, 2, 3, 4]
   /// print(chars.takeLast(2)) // [8, 9]
@@ -447,7 +447,7 @@ extension IterableX<E> on Iterable<E> {
   /// Returns a list containing last [n] elements.
   ///
   /// ```dart
-  /// val chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  /// var chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   /// print(chars.take(3)) // [1, 2, 3]
   /// print(chars.takeWhile((it) => it < 5) // [1, 2, 3, 4]
   /// print(chars.takeLast(2)) // [8, 9]
@@ -458,10 +458,29 @@ extension IterableX<E> on Iterable<E> {
     return list.sublist(length - n);
   }
 
+  /// Returns a list containing the elements at every [n]th index, starting
+  /// from the index [offset].
+  ///
+  /// ```dart
+  /// var chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  /// print(chars.takeIndexInterval(2)); // [1, 3, 5, 7, 9]
+  /// print(chars.takeIndexInterval(2, offset: 1)); // [2, 4, 6, 8]
+  /// ```
+  List<E> indexIntervals(int n, {int offset = 0}) {
+    var origList = this is List<E> ? this as List<E> : toList();
+    if (n < 1) throw ArgumentError('interval must be >= 1.');
+    if (offset < 0) throw ArgumentError('offset must be >= 0');
+    var returnList = <E>[];
+    for (var i = offset; i< origList.length; i+= n) {
+      returnList.add(origList[i]);
+    }
+    return returnList;
+  }
+
   //// Returns the first elements satisfying the given [predicate].
   ///
   /// ```dart
-  /// val chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  /// var chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   /// print(chars.take(3)) // [1, 2, 3]
   /// print(chars.takeWhile((it) => it < 5) // [1, 2, 3, 4]
   /// print(chars.takeLast(2)) // [8, 9]
@@ -477,7 +496,7 @@ extension IterableX<E> on Iterable<E> {
   /// Returns the last elements satisfying the given [predicate].
   ///
   /// ```dart
-  /// val chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  /// var chars = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   /// print(chars.take(3)) // [1, 2, 3]
   /// print(chars.takeWhile((it) => it < 5) // [1, 2, 3, 4]
   /// print(chars.takeLast(2)) // [8, 9]

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -471,7 +471,7 @@ extension IterableX<E> on Iterable<E> {
     if (n < 1) throw ArgumentError('interval must be >= 1.');
     if (offset < 0) throw ArgumentError('offset must be >= 0');
     var returnList = <E>[];
-    for (var i = offset; i< origList.length; i+= n) {
+    for (var i = offset; i < origList.length; i += n) {
       returnList.add(origList[i]);
     }
     return returnList;

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -54,4 +54,29 @@ extension IterableNumX<T extends num> on Iterable<T> {
       return (x + y) / 2;
     }
   }
+
+  /// Returns the "mode" of the elements in this collection, or the element
+  /// which appears most often.
+  ///
+  /// Empty collections throw an error.
+  /// `null` values are ignored.
+  ///
+  /// Collections with multiple modes (or multiple elements tied for the highest
+  /// number of occurrences) return one of those modes.
+  num mode() {
+    if (length == 0) throw StateError('No elements in collection');
+    final values = toList();
+    var occurrences = <num, int>{};
+    num bestElem;
+    for (num value in values) {
+      if (value == null) continue;
+      bestElem ??= value;
+      occurrences[value] ??= 0;
+      occurrences[value]++;
+      if (occurrences[value] > occurrences[bestElem]) {
+        bestElem = value;
+      }
+    }
+    return bestElem;
+  }
 }

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -41,10 +41,8 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Empty collections throw an error.
   /// `null` values are ignored.
   double median() {
-    if (length == 0) throw StateError('No elements in collection');
-    final values = toList()
-      ..removeWhere((item) => item == null)
-      ..sort();
+    if (isEmpty) throw StateError('No elements in collection');
+    final values = whereNotNull().toList()..sort();
     final size = values.length;
     if (size.isOdd) {
       return values[(size / 2).floor()].toDouble();
@@ -64,7 +62,7 @@ extension IterableNumX<T extends num> on Iterable<T> {
   /// Collections with multiple modes (or multiple elements tied for the highest
   /// number of occurrences) return one of those modes.
   num mode() {
-    if (length == 0) throw StateError('No elements in collection');
+    if (isEmpty) throw StateError('No elements in collection');
     final values = toList();
     var occurrences = <num, int>{};
     num bestElem;
@@ -78,5 +76,36 @@ extension IterableNumX<T extends num> on Iterable<T> {
       }
     }
     return bestElem;
+  }
+
+  /// Returns the variance of this collection. The formula for variance changes
+  /// slightly based on whether this collection represents a population
+  /// or a sample of a population. By default, this method assumes that this
+  /// collection is a sample, but you can tweak that behavior with the [sample]
+  /// parameter.
+  ///
+  /// `null` values are ignored, and empty collections return 0.
+  double variance({bool sample = true}) {
+    if (isEmpty || length == 1) {
+      return 0.0;
+    }
+    var data = whereNotNull();
+    var varianceSum = 0.0;
+    var avg = data.average();
+    for (var elem in data) {
+      varianceSum += pow(elem - avg, 2);
+    }
+    return varianceSum / (data.length - (sample == true ? 1 : 0));
+  }
+
+  /// Returns the standard deviation of this collection. The formula for
+  /// standard deviation changes slightly based on whether this collection
+  /// represents a population or a sample of a population. By default, this
+  /// method assumes that this collection is a sample, but you can tweak that
+  /// behavior with the [sample] parameter.
+  ///
+  /// `null` values are ignored, and empty collections return 0.
+  double stdDev({bool sample = true}) {
+    return sqrt(variance(sample: sample));
   }
 }

--- a/test/iterable_num_test.dart
+++ b/test/iterable_num_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:test/test.dart';
 import 'package:dartx/dartx.dart';
 
@@ -18,13 +20,13 @@ void main() {
     });
 
     test('.average()', () {
-      expect(() => <int>[].average(), throwsStateError);
+      expect(<int>[].average, throwsStateError);
       expect([1, 2, 3, 4, 5].average(), 3.0);
       expect([1, 2, 0, 3, 4, null, 5, 6, null, 9].average(), 3.0);
     });
 
     test('.median()', () {
-      expect(() => <int>[].median(), throwsStateError);
+      expect(<int>[].median, throwsStateError);
       // odd
       expect([1, 2, 3, 4, 5].median(), 3);
       expect([5, 3, 2, 4, 1].median(), 3);
@@ -40,11 +42,27 @@ void main() {
     });
 
     test('.mode()', () {
-      expect(() => <int>[].mode(), throwsStateError);
+      expect(<int>[].mode, throwsStateError);
       expect([1, 2, 2, 4, 5].mode(), 2);
       expect([5, 3, 2, 4, 6, 1, 5].mode(), 5);
       expect([5, 3, 2, 4, 1, 1, null, null, null].mode(), 1);
       expect([2.5, 2, 2.5, 4, 5].mode(), 2.5);
+    });
+
+    test('.variance()', () {
+      expect(<int>[].variance(), 0);
+      expect([1].variance(), 0);
+      expect([2, 4, 6, 8, 10].variance(), 10);
+      expect([2, 4, 6, 8, 10].variance(sample: false), 8);
+      expect([2, 4, 6, 8, 10, null, null, null].variance(), 10);
+    });
+
+    test('.stdDev()', () {
+      expect(<int>[].stdDev(), 0);
+      expect([1].stdDev(), 0);
+      expect([2, 4, 6, 8, 10].stdDev(), sqrt(10));
+      expect([2, 4, 6, 8, 10].stdDev(sample: false), sqrt(8));
+      expect([2, 4, 6, 8, 10, null, null, null].stdDev(), sqrt(10));
     });
   });
 }

--- a/test/iterable_num_test.dart
+++ b/test/iterable_num_test.dart
@@ -38,5 +38,13 @@ void main() {
       // handles double values
       expect([1.5, 2, 2.5, 4, 5].median(), 2.5);
     });
+
+    test('.mode()', () {
+      expect(() => <int>[].mode(), throwsStateError);
+      expect([1, 2, 2, 4, 5].mode(), 2);
+      expect([5, 3, 2, 4, 6, 1, 5].mode(), 5);
+      expect([5, 3, 2, 4, 1, 1, null, null, null].mode(), 1);
+      expect([2.5, 2, 2.5, 4, 5].mode(), 2.5);
+    });
   });
 }

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -335,6 +335,13 @@ void main() {
       expect([1, 2, 3].takeLast(2), [2, 3]);
     });
 
+    test('.indexIntervals()', () {
+      expect([].indexIntervals(2), []);
+      expect([1, 2, 3, 4, 5, 6].indexIntervals(3), [1, 4]);
+      expect([2, 3, 4, 5, 6, 7, 8].indexIntervals(2, offset: 1), [3, 5, 7]);
+      expect([2, 3, 4].indexIntervals(4), [2]);
+    });
+
     test('.firstWhile()', () {
       expect([].firstWhile((e) => true), []);
       expect([1, 2, 3].firstWhile((e) => false), []);


### PR DESCRIPTION
The former-most is for the Iterable extension, whereas the latter three are for the Iterable\<num\> extension. Tests have been provided for all three. I've adhered to the formatting guidelines from `analysis_options.yaml`, but you're welcome to reformat/tweak my code as necessary.