### PR TITLE
Move all extension methods into their own extensions

### DIFF
--- a/lib/dartx.dart
+++ b/lib/dartx.dart
@@ -6,8 +6,8 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:characters/characters.dart';
-import 'package:collection/collection.dart' hide DelegatingList;
+import 'package:characters/characters.dart' as characters;
+import 'package:collection/collection.dart' as collection;
 import 'package:crypto/crypto.dart' as crypto;
 
 export 'package:time/time.dart';

--- a/lib/src/comparable.dart
+++ b/lib/src/comparable.dart
@@ -1,12 +1,23 @@
 part of dartx;
 
 /// Provides comparison operators for [Comparable] types.
-extension ComparableX<T extends Comparable<T>> on T {
+extension ComparableSmallerExtension<T extends Comparable<T>> on T {
   bool operator <(T other) => compareTo(other) < 0;
-  bool operator <=(T other) => compareTo(other) <= 0;
-  bool operator >(T other) => compareTo(other) > 0;
-  bool operator >=(T other) => compareTo(other) >= 0;
+}
 
+extension ComparableSmallerEqualsExtension<T extends Comparable<T>> on T {
+  bool operator <=(T other) => compareTo(other) <= 0;
+}
+
+extension ComparableBiggerExtension<T extends Comparable<T>> on T {
+  bool operator >(T other) => compareTo(other) > 0;
+}
+
+extension ComparableBiggerEqualsExtension<T extends Comparable<T>> on T {
+  bool operator >=(T other) => compareTo(other) >= 0;
+}
+
+extension ComparableCoerceInExtension<T extends Comparable<T>> on T {
   /// Ensures that this value lies in the specified range
   /// [minimumValue]..[maximumValue].
   ///
@@ -22,26 +33,34 @@ extension ComparableX<T extends Comparable<T>> on T {
     if (maximumValue != null && this > maximumValue) return maximumValue;
     return this;
   }
+}
 
+extension ComparableCoerceAtLeastExtension<T extends Comparable<T>> on T {
   /// Ensures that this value is not less than the specified [minimumValue].
   ///
   /// @return this value if it's greater than or equal to the [minimumValue]
   /// or the [minimumValue] otherwise.
   T coerceAtLeast(T minimumValue) => this < minimumValue ? minimumValue : this;
+}
 
+extension ComparableCoerceAtMostExtension<T extends Comparable<T>> on T {
   /// Ensures that this value is not greater than the specified [maximumValue].
   ///
   /// @return this value if it's less than or equal to the [maximumValue]
   /// or the [maximumValue] otherwise.
   T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
+}
 
+extension ComparableBetweenExtension<T extends Comparable<T>> on T {
   /// Returns true when between [first] and [endInclusive]. The order of the
   /// arguments doesn't matter.
   ///
   /// Alias for `first.rangeTo(endInclusive).contains(this)`
   bool between(T first, T endInclusive) =>
       first.rangeTo(endInclusive).contains(this);
+}
 
+extension ComparableInRangeExtension<T extends Comparable<T>> on T {
   /// Returns true if in the [range].
   bool inRange(Range<T> range) => range.contains(this);
 }

--- a/lib/src/comparator.dart
+++ b/lib/src/comparator.dart
@@ -1,6 +1,6 @@
 part of dartx;
 
-extension CompararatorX<T> on Comparator<T> {
+extension CompararatorComposeExtensions<T> on Comparator<T> {
   /// return a new comparator,
   /// that sorts the items first by the criteria of this comparator,
   /// then by the criteria of the given comparator
@@ -13,7 +13,9 @@ extension CompararatorX<T> on Comparator<T> {
       return then(a, b);
     };
   }
+}
 
+extension CompararatorReverseExtensions<T> on Comparator<T> {
   /// reverse the sort order of this comparator
   Comparator<T> reverse() => (a, b) => this(b, a);
 }

--- a/lib/src/function.dart
+++ b/lib/src/function.dart
@@ -6,82 +6,114 @@ typedef Function2<A, B, R> = R Function(A a, B b);
 typedef Function3<A, B, C, R> = R Function(A a, B b, C c);
 typedef Function4<A, B, C, D, R> = R Function(A a, B b, C c, D d);
 
-extension Function0X<R> on Function0<R> {
+extension Function0InvokeExtension<R> on Function0<R> {
   /// Invokes this function and returns it's return value.
   @Deprecated('Use `call()`')
   R invoke() => this();
 }
 
-extension Function1X<A, R> on Function1<A, R> {
+extension Function1InvokeExtensions<A, R> on Function1<A, R> {
   /// Invokes this function and returns it's return value.
   R invoke(A first) => this(first);
+}
 
+extension Function1PartialExtensions<A, R> on Function1<A, R> {
   Function0<R> partial(A first) => () => this(first);
 }
 
-extension Function2X<A, B, R> on Function2<A, B, R> {
+extension Function2InvokeExtension<A, B, R> on Function2<A, B, R> {
   /// Invokes this function and returns it's return value.
   R invoke(A first, B second) => this(first, second);
+}
 
-  Function1<A, Function1<B, R>> curry() =>
-      (A first) => (B second) => this(first, second);
-
+extension Function2PartialExtension<A, B, R> on Function2<A, B, R> {
   Function1<B, R> partial(A first) => (B second) => this(first, second);
+}
 
+extension Function2Partial2Extension<A, B, R> on Function2<A, B, R> {
   Function0<R> partial2(A first, B second) => () => this(first, second);
+}
 
+extension Function2FlipExtension<A, B, R> on Function2<A, B, R> {
   Function2<B, A, R> flip() => (B second, A first) => this(first, second);
 }
 
-extension Curry2X<A, B, R> on Function1<A, Function1<B, R>> {
+extension Function2CurryExtension<A, B, R> on Function2<A, B, R> {
+  Function1<A, Function1<B, R>> curry() =>
+      (A first) => (B second) => this(first, second);
+}
+
+extension Function2UncurryExtension<A, B, R> on Function1<A, Function1<B, R>> {
   Function2<A, B, R> uncurry() => (A first, B second) => this(first)(second);
 }
 
-extension Function3X<R, A, B, C> on Function3<A, B, C, R> {
+extension Function3InvokeExtension<R, A, B, C> on Function3<A, B, C, R> {
   /// Invokes this function and returns it's return value.
   R invoke(A first, B second, C third) => this(first, second, third);
+}
 
+extension Function3CurryExtension<R, A, B, C> on Function3<A, B, C, R> {
   Function1<A, Function1<B, Function1<C, R>>> curry() =>
       (A first) => (B second) => (C third) => this(first, second, third);
+}
 
+extension Function3PartialExtension<R, A, B, C> on Function3<A, B, C, R> {
   Function2<B, C, R> partial(A first) =>
       (B second, C third) => this(first, second, third);
+}
 
+extension Function3Partial2Extension<R, A, B, C> on Function3<A, B, C, R> {
   Function1<C, R> partial2(A first, B second) =>
       (C third) => this(first, second, third);
+}
 
+extension Function3Partial3Extension<R, A, B, C> on Function3<A, B, C, R> {
   Function0<R> partial3(A first, B second, C third) =>
       () => this(first, second, third);
 }
 
-extension Curry3X<A, B, C, R> on Function1<A, Function1<B, Function1<C, R>>> {
+extension Function3UncurryExtension<A, B, C, R>
+    on Function1<A, Function1<B, Function1<C, R>>> {
   Function3<A, B, C, R> uncurry() =>
       (A first, B second, C third) => this(first)(second)(third);
 }
 
-extension Function4X<R, A, B, C, D> on Function4<A, B, C, D, R> {
+extension Function4InvokeExtension<R, A, B, C, D> on Function4<A, B, C, D, R> {
   /// Invokes this function and returns it's return value.
   R invoke(A first, B second, C third, D fourth) =>
       this(first, second, third, fourth);
+}
 
+extension Function4CurryExtension<R, A, B, C, D> on Function4<A, B, C, D, R> {
   Function1<A, Function1<B, Function1<C, Function1<D, R>>>> curry() =>
       (A first) => (B second) =>
           (C third) => (D fourth) => this(first, second, third, fourth);
+}
 
+extension Function4PartialExtension<R, A, B, C, D> on Function4<A, B, C, D, R> {
   Function3<B, C, D, R> partial(A first) =>
       (B second, C third, D fourth) => this(first, second, third, fourth);
+}
 
+extension Function4Partial2Extension<R, A, B, C, D>
+    on Function4<A, B, C, D, R> {
   Function2<C, D, R> partial2(A first, B second) =>
       (C third, D fourth) => this(first, second, third, fourth);
+}
 
+extension Function4Partial3Extension<R, A, B, C, D>
+    on Function4<A, B, C, D, R> {
   Function1<D, R> partial3(A first, B second, C third) =>
       (D fourth) => this(first, second, third, fourth);
+}
 
+extension Function4Partial4Extension<R, A, B, C, D>
+    on Function4<A, B, C, D, R> {
   Function0<R> partial4(A first, B second, C third, D fourth) =>
       () => this(first, second, third, fourth);
 }
 
-extension Curry4X<A, B, C, D, R>
+extension Function4UncurryExtension<A, B, C, D, R>
     on Function1<A, Function1<B, Function1<C, Function1<D, R>>>> {
   Function4<A, B, C, D, R> uncurry() =>
       (A first, B second, C third, D fourth) =>

--- a/lib/src/io/directory.dart
+++ b/lib/src/io/directory.dart
@@ -1,6 +1,6 @@
 part of dartx_io;
 
-extension DirectoryX on Directory {
+extension DirectorySubDirExtension on Directory {
   Directory subdir(String part1,
       [String? part2,
       String? part3,
@@ -12,7 +12,9 @@ extension DirectoryX on Directory {
       path_helper.join(path, part1, part2, part3, part4, part5, part6, part7),
     );
   }
+}
 
+extension DirectoryCopyRecursivelyExtension on Directory {
   /// Copies all of the files in this directory to [target].
   ///
   /// This is similar to `cp -R <from> <to>`:
@@ -43,7 +45,9 @@ extension DirectoryX on Directory {
       }
     }
   }
+}
 
+extension DirectoryContainsExtension on Directory {
   /// Checks if this directory contains the [entity].
   ///
   /// The [entity] can be a [File] or a [Directory].
@@ -58,7 +62,9 @@ extension DirectoryX on Directory {
     return entities.any(
         (element) => FileSystemEntity.identicalSync(entity.path, element.path));
   }
+}
 
+extension DirectoryContainsSyncExtension on Directory {
   /// Checks if this directory contains the [entity].
   ///
   /// The [entity] can be a [File] or a [Directory].

--- a/lib/src/io/file.dart
+++ b/lib/src/io/file.dart
@@ -1,13 +1,15 @@
 part of dartx_io;
 
-extension FileX on File {
+extension FileAppendBytesExtension on File {
   /// Appends an array of [bytes] to the content of this file.
   Future<void> appendBytes(List<int> bytes) async {
     final raf = await open(mode: FileMode.writeOnlyAppend);
     await raf.writeFrom(bytes);
     await raf.close();
   }
+}
 
+extension FileAppendStringExtension on File {
   /// Appends a [string] to the content of this file using UTF-8 or the
   /// specified [encoding].
   Future<void> appendString(String string, {Encoding encoding = utf8}) async {
@@ -15,7 +17,9 @@ extension FileX on File {
     await raf.writeString(string);
     await raf.close();
   }
+}
 
+extension FileForEachBlockExtension on File {
   /// Reads file by byte blocks and calls [action] for each block read.
   ///
   /// This functions passes the byte buffer to the [action] function.
@@ -24,6 +28,7 @@ extension FileX on File {
   Future<void> forEachBlock(
       int blockSize, void Function(Uint8List buffer) action) async {
     final raf = await open();
+    // ignore: literal_only_boolean_expressions
     while (true) {
       final buffer = await raf.read(blockSize);
       if (buffer.length == blockSize) {

--- a/lib/src/io/file_system_entity.dart
+++ b/lib/src/io/file_system_entity.dart
@@ -1,6 +1,6 @@
 part of dartx_io;
 
-extension FileSystemEntityX on FileSystemEntity {
+extension FileSystemEntityNameExtension on FileSystemEntity {
   /// Gets the part of [path] after the last separator.
   /// ```dart
   /// File('path/to/foo.dart').name; // -> 'foo.dart'
@@ -12,7 +12,9 @@ extension FileSystemEntityX on FileSystemEntity {
   /// Directory('path/to/').name; // -> 'to'
   /// ```
   String get name => path_helper.basename(path);
+}
 
+extension FileSystemEntityNameWithoutExtensionExtension on FileSystemEntity {
   /// Gets the part of [path] after the last separator, and without any trailing
   /// file extension.
   /// ```dart
@@ -24,7 +26,9 @@ extension FileSystemEntityX on FileSystemEntity {
   /// File('path/to/foo.dart/').nameWithoutExtension; // -> 'foo'
   /// ```
   String get nameWithoutExtension => path_helper.basenameWithoutExtension(path);
+}
 
+extension FileSystemEntityDirNameExtension on FileSystemEntity {
   /// Gets the part of [path] before the last separator.
   /// ```dart
   /// File().dirname('path/to/foo.dart'); // -> 'path/to'
@@ -49,7 +53,9 @@ extension FileSystemEntityX on FileSystemEntity {
   /// Directory('').dirName;  // -> '.'
   /// ```
   String get dirName => path_helper.dirname(path);
+}
 
+extension FileSystemEntityIsWithinExtension on FileSystemEntity {
   /// Returns `true` if this entity is a path beneath `parent`, and `false`
   /// otherwise.
   /// ```dart
@@ -58,7 +64,9 @@ extension FileSystemEntityX on FileSystemEntity {
   /// Directory('/root/path').isWithin(Directory('/root/path')) // -> false
   /// ```
   bool isWithin(Directory parent) => path_helper.isWithin(parent.path, path);
+}
 
+extension FileSystemEntityWithNameExtension on FileSystemEntity {
   ///Returns a new [File] with the `name` part changed
   ///```dart
   ///File('path/to/foo.dart').withName('bar.txt'); // -> File('path/to/bar.txt')
@@ -67,7 +75,9 @@ extension FileSystemEntityX on FileSystemEntity {
   FileSystemEntity withName(String newName) {
     return File('$dirName${Platform.pathSeparator}$newName');
   }
+}
 
+extension FileSystemEntityExtensionExtension on FileSystemEntity {
   ///Returns the file extension of the [path], the portion of the `name`
   ///from the last '.' to the end (including the '.' itself).
   ///```dart

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1,30 +1,33 @@
 part of dartx;
 
-const _groupBy = groupBy;
-
-/// Extensions for iterables
-extension IterableX<E> on Iterable<E> {
+extension IterableSecondItem<E> on Iterable<E> {
   /// Second element.
   ///
   /// ```dart
   /// [1, 2, 3].second; // 2
   /// ```
   E? get second => elementAt(1);
+}
 
+extension IterableThirdItem<E> on Iterable<E> {
   /// Third element.
   ///
   /// ```dart
   /// [1, 2, 3].third; // 3
   /// ```
   E get third => elementAt(2);
+}
 
+extension IterableForthItem<E> on Iterable<E> {
   /// Fourth element.
   ///
   /// ```dart
   /// [1, 2, 3, 4].fourth; // 4
   /// ```
   E get fourth => elementAt(3);
+}
 
+extension IterableElementAtOrNull<E> on Iterable<E> {
   /// Returns an element at the given [index] or `null` if the [index] is out of
   /// bounds of this collection.
   ///
@@ -41,7 +44,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return null;
   }
+}
 
+extension IterableElementAtOrDefault<E> on Iterable<E> {
   /// Returns an element at the given [index] or [defaultValue] if the [index]
   /// is out of bounds of this collection.
   ///
@@ -53,7 +58,9 @@ extension IterableX<E> on Iterable<E> {
   E elementAtOrDefault(int index, E defaultValue) {
     return elementAtOrElse(index, (_) => defaultValue);
   }
+}
 
+extension IterableElementAtOrElse<E> on Iterable<E> {
   /// Returns an element at the given [index] or the result of calling the
   /// [defaultValue] function if the [index] is out of bounds of this
   /// collection.
@@ -71,7 +78,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return defaultValue(index);
   }
+}
 
+extension IterableFirstOrNull<E> on Iterable<E> {
   /// First element or `null` if the collection is empty.
   ///
   /// ```dart
@@ -79,7 +88,9 @@ extension IterableX<E> on Iterable<E> {
   /// final emptyFirst = [].firstOrNull; // null
   /// ```
   E? get firstOrNull => isNotEmpty ? first : null;
+}
 
+extension IterableFirstOrDefault<E> on Iterable<E> {
   /// First element or `defaultValue` if the collection is empty.
   ///
   /// ```dart
@@ -87,7 +98,9 @@ extension IterableX<E> on Iterable<E> {
   /// final emptyFirst = [].firstOrDefault(-1); // -1
   /// ```
   E firstOrDefault(E defaultValue) => isNotEmpty ? first : defaultValue;
+}
 
+extension IterableFirstOrNullWhere<E> on Iterable<E> {
   /// Returns the first element matching the given [predicate], or `null` if no
   /// such element was found.
   ///
@@ -102,7 +115,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return null;
   }
+}
 
+extension IterableLastOrNull<E> on Iterable<E> {
   /// Last element or `null` if the collection is empty.
   ///
   /// ```dart
@@ -110,10 +125,15 @@ extension IterableX<E> on Iterable<E> {
   /// final emptyLast = [].firstOrNull; // null
   /// ```
   E? get lastOrNull => isNotEmpty ? last : null;
+}
 
+extension IterableLastOrElse<E> on Iterable<E> {
   /// Last element or `defaultValue` if the collection is empty.
-  E lastOrElse(E defaultValue) => lastOrNull ?? defaultValue;
+  E lastOrElse(E defaultValue) =>
+      IterableLastOrNull(this).lastOrNull ?? defaultValue;
+}
 
+extension IterableLastOrNullWhere<E> on Iterable<E> {
   /// Returns the last element matching the given [predicate], or `null` if no
   /// such element was found.
   E? lastOrNullWhere(bool Function(E element) predicate) {
@@ -125,7 +145,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return match;
   }
+}
 
+extension IterableAll<E> on Iterable<E> {
   /// Returns true if all elements match the given [predicate] or if the
   /// collection is empty.
   bool all(bool Function(E element) predicate) {
@@ -136,11 +158,15 @@ extension IterableX<E> on Iterable<E> {
     }
     return true;
   }
+}
 
+extension IterableNone<E> on Iterable<E> {
   /// Returns true if no entries match the given [predicate] or if the
   /// collection is empty.
   bool none(bool Function(E element) predicate) => !any(predicate);
+}
 
+extension IterableSlice<E> on Iterable<E> {
   /// Returns a new list containing elements at indices between [start]
   /// (inclusive) and [end] (inclusive).
   ///
@@ -161,7 +187,9 @@ extension IterableX<E> on Iterable<E> {
 
     return list.sublist(_start, _end + 1);
   }
+}
 
+extension IterableForEachIndexed<E> on Iterable<E> {
   /// Performs the given [action] on each element, providing sequential index
   /// with the element.
   void forEachIndexed(void Function(E element, int index) action) {
@@ -170,7 +198,9 @@ extension IterableX<E> on Iterable<E> {
       action(element, index++);
     }
   }
+}
 
+extension IterableContainsAll<E> on Iterable<E> {
   /// Checks if all elements in the specified [collection] are contained in
   /// this collection.
   bool containsAll(Iterable<E> collection) {
@@ -179,7 +209,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return true;
   }
+}
 
+extension IterableContainsAny<E> on Iterable<E> {
   /// Checks if any elements in the specified [collection] are contained in
   /// this collection.
   bool containsAny(Iterable<E> collection) {
@@ -188,7 +220,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return false;
   }
+}
 
+extension IterableContentEquals<E> on Iterable<E> {
   /// Returns true if this collection is structurally equal to the [other]
   /// collection.
   ///
@@ -212,9 +246,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return !it2.moveNext();
   }
+}
 
-  //Soting operations
-
+extension IterableSorted<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to natural sort
   /// order.
   List<E> sorted() {
@@ -222,7 +256,9 @@ extension IterableX<E> on Iterable<E> {
     list.sort();
     return list;
   }
+}
 
+extension IterableSortedDescending<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to descending
   /// natural sort order.
   List<E> sortedDescending() {
@@ -230,7 +266,9 @@ extension IterableX<E> on Iterable<E> {
     list.sort((a, b) => -(a as Comparable).compareTo(b));
     return list;
   }
+}
 
+extension IterableSortedBy<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to natural sort
   /// order of the values returned by specified [selector] function.
   ///
@@ -242,7 +280,9 @@ extension IterableX<E> on Iterable<E> {
   _SortedList<E> sortedBy(Comparable Function(E element) selector) {
     return _SortedList<E>._withSelector(this, selector, 1, null);
   }
+}
 
+extension IterableSortedByDescending<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to descending
   /// natural sort order of the values returned by specified [selector]
   /// function.
@@ -255,7 +295,9 @@ extension IterableX<E> on Iterable<E> {
   _SortedList<E> sortedByDescending(Comparable Function(E element) selector) {
     return _SortedList<E>._withSelector(this, selector, -1, null);
   }
+}
 
+extension IterableSortedWith<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to specified
   /// [comparator].
   ///
@@ -267,7 +309,9 @@ extension IterableX<E> on Iterable<E> {
   _SortedList<E> sortedWith(Comparator<E> comparator) {
     return _SortedList<E>._(this, comparator);
   }
+}
 
+extension IterableJoinToString<E> on Iterable<E> {
   /// Creates a string from all the elements separated using [separator] and
   /// using the given [prefix] and [postfix] if supplied.
   ///
@@ -304,9 +348,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return buffer.toString();
   }
+}
 
-  //Math operations
-
+extension IterableSumBy<E> on Iterable<E> {
   /// Returns the sum of all values produced by [selector] function applied to
   /// each element in the collection.
   double sumBy(num Function(E element) selector) {
@@ -316,7 +360,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return sum;
   }
+}
 
+extension IterableAverageBy<E> on Iterable<E> {
   /// Returns the average of values returned by [selector] for all elements in
   /// the collection.
   double averageBy(num Function(E element) selector) {
@@ -334,33 +380,16 @@ extension IterableX<E> on Iterable<E> {
       return sum / count;
     }
   }
+}
 
+extension InterableMin<E> on Iterable<E> {
   /// Returns the smallest element or `null` if there are no elements.
   ///
   /// All elements must be of type [Comparable].
   E? min() => _minMax(-1);
+}
 
-  /// Returns the first element yielding the smallest value of the given
-  /// [selector] or `null` if there are no elements.
-  E? minBy(Comparable Function(E element) selector) => _minMaxBy(-1, selector);
-
-  /// Returns the first element having the smallest value according to the
-  /// provided [comparator] or `null` if there are no elements.
-  E? minWith(Comparator<E> comparator) => _minMaxWith(-1, comparator);
-
-  /// Returns the largest element or `null` if there are no elements.
-  ///
-  /// All elements must be of type [Comparable].
-  E? max() => _minMax(1);
-
-  /// Returns the first element yielding the largest value of the given
-  /// [selector] or `null` if there are no elements.
-  E? maxBy(Comparable Function(E element) selector) => _minMaxBy(1, selector);
-
-  /// Returns the first element having the largest value according to the
-  /// provided [comparator] or `null` if there are no elements.
-  E? maxWith(Comparator<E> comparator) => _minMaxWith(1, comparator);
-
+extension _MinMaxHelper<E> on Iterable<E> {
   E? _minMax(int order) {
     final it = iterator;
     if (!it.moveNext()) {
@@ -411,7 +440,40 @@ extension IterableX<E> on Iterable<E> {
 
     return currentMin;
   }
+}
 
+extension IterableMinBy<E> on Iterable<E> {
+  /// Returns the first element yielding the smallest value of the given
+  /// [selector] or `null` if there are no elements.
+  E? minBy(Comparable Function(E element) selector) => _minMaxBy(-1, selector);
+}
+
+extension IterableMinWith<E> on Iterable<E> {
+  /// Returns the first element having the smallest value according to the
+  /// provided [comparator] or `null` if there are no elements.
+  E? minWith(Comparator<E> comparator) => _minMaxWith(-1, comparator);
+}
+
+extension IterableMax<E> on Iterable<E> {
+  /// Returns the largest element or `null` if there are no elements.
+  ///
+  /// All elements must be of type [Comparable].
+  E? max() => _minMax(1);
+}
+
+extension IterableMaxBy<E> on Iterable<E> {
+  /// Returns the first element yielding the largest value of the given
+  /// [selector] or `null` if there are no elements.
+  E? maxBy(Comparable Function(E element) selector) => _minMaxBy(1, selector);
+}
+
+extension IterableMaxWith<E> on Iterable<E> {
+  /// Returns the first element having the largest value according to the
+  /// provided [comparator] or `null` if there are no elements.
+  E? maxWith(Comparator<E> comparator) => _minMaxWith(1, comparator);
+}
+
+extension IterableCount<E> on Iterable<E> {
   /// Returns the number of elements matching the given [predicate].
   ///
   /// If no [predicate] is given, this equals to [length].
@@ -429,14 +491,16 @@ extension IterableX<E> on Iterable<E> {
 
     return count;
   }
+}
 
-  // Transformations
-
+extension IterableReversed<E> on Iterable<E> {
   /// Returns an [Iterable] of the objects in this list in reverse order.
   Iterable<E> get reversed {
     return this is List<E> ? (this as List<E>).reversed : toList().reversed;
   }
+}
 
+extension IterableTakeFirst<E> on Iterable<E> {
   /// Returns a list containing first [n] elements.
   ///
   /// ```dart
@@ -450,7 +514,9 @@ extension IterableX<E> on Iterable<E> {
     final list = this is List<E> ? this as List<E> : toList();
     return list.sublist(0, n);
   }
+}
 
+extension IterableTakeLast<E> on Iterable<E> {
   /// Returns a list containing last [n] elements.
   ///
   /// ```dart
@@ -464,7 +530,9 @@ extension IterableX<E> on Iterable<E> {
     final list = this is List<E> ? this as List<E> : toList();
     return list.sublist(length - n);
   }
+}
 
+extension IterableFirstWhile<E> on Iterable<E> {
   //// Returns the first elements satisfying the given [predicate].
   ///
   /// ```dart
@@ -480,7 +548,9 @@ extension IterableX<E> on Iterable<E> {
       yield element;
     }
   }
+}
 
+extension IterableLastWhile<E> on Iterable<E> {
   /// Returns the last elements satisfying the given [predicate].
   ///
   /// ```dart
@@ -498,47 +568,67 @@ extension IterableX<E> on Iterable<E> {
     }
     return list;
   }
+}
 
+extension IterableFilter<E> on Iterable<E> {
   /// Returns all elements matching the given [predicate].
   Iterable<E> filter(bool Function(E element) predicate) => where(predicate);
+}
 
+extension IterableFilterIndexed<E> on Iterable<E> {
   /// Returns all elements that satisfy the given [predicate].
   Iterable<E> filterIndexed(bool Function(E element, int index) predicate) =>
-      whereIndexed(predicate);
+      IterableWhereIndexed(this).whereIndexed(predicate);
+}
 
+extension IterableFilterTo<E> on Iterable<E> {
   /// Appends all elements matching the given [predicate] to the given
   /// [destination].
   void filterTo(List<E> destination, bool Function(E element) predicate) =>
       whereTo(destination, predicate);
+}
 
+extension IterableFilterIndexedTo<E> on Iterable<E> {
   /// Appends all elements matching the given [predicate] to the given
   /// [destination].
   void filterIndexedTo(
           List<E> destination, bool Function(E element, int index) predicate) =>
       whereIndexedTo(destination, predicate);
+}
 
+extension IterableFilterNot<E> on Iterable<E> {
   /// Returns all elements not matching the given [predicate].
   Iterable<E> filterNot(bool Function(E element) predicate) =>
-      whereNot(predicate);
+      IterableWhereNot(this).whereNot(predicate);
+}
 
+extension IterableFilterNotIndexed<E> on Iterable<E> {
   /// Returns all elements not matching the given [predicate].
   Iterable<E> filterNotIndexed(bool Function(E element, int index) predicate) =>
-      whereNotIndexed(predicate);
+      IterableWhereNotIndexed(this).whereNotIndexed(predicate);
+}
 
+extension IterableFilterNotTo<E> on Iterable<E> {
   /// Appends all elements not matching the given [predicate] to the given
   /// [destination].
   void filterNotTo(List<E> destination, bool Function(E element) predicate) =>
       whereNotTo(destination, predicate);
+}
 
+extension IterableFilterNotToIndexed<E> on Iterable<E> {
   /// Appends all elements not matching the given [predicate] to the given
   /// [destination].
   void filterNotToIndexed(
           List<E> destination, bool Function(E element, int index) predicate) =>
       whereNotToIndexed(destination, predicate);
+}
 
+extension IterableFilterNotNull<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] with all elements which are not null.
   Iterable<E> filterNotNull() => where((element) => element != null);
+}
 
+extension IterableWhereIndexed<E> on Iterable<E> {
   /// Returns all elements that satisfy the given [predicate].
   Iterable<E> whereIndexed(
       bool Function(E element, int index) predicate) sync* {
@@ -549,7 +639,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereTo<E> on Iterable<E> {
   /// Appends all elements matching the given [predicate] to the given
   /// [destination].
   void whereTo(List<E> destination, bool Function(E element) predicate) {
@@ -559,7 +651,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereIndexedTo<E> on Iterable<E> {
   /// Appends all elements matching the given [predicate] to the given
   /// [destination].
   void whereIndexedTo(
@@ -571,7 +665,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereNot<E> on Iterable<E> {
   /// Returns all elements not matching the given [predicate].
   Iterable<E> whereNot(bool Function(E element) predicate) sync* {
     for (final element in this) {
@@ -580,7 +676,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereNotIndexed<E> on Iterable<E> {
   /// Returns all elements not matching the given [predicate].
   Iterable<E> whereNotIndexed(
       bool Function(E element, int index) predicate) sync* {
@@ -591,7 +689,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereNotTo<E> on Iterable<E> {
   /// Appends all elements not matching the given [predicate] to the given
   /// [destination].
   void whereNotTo(List<E> destination, bool Function(E element) predicate) {
@@ -601,7 +701,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereNotToIndexed<E> on Iterable<E> {
   /// Appends all elements not matching the given [predicate] to the given
   /// [destination].
   void whereNotToIndexed(
@@ -613,10 +715,14 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableWhereNotNull<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] with all elements which are not null.
   Iterable<E> whereNotNull() => where((element) => element != null);
+}
 
+extension IterableMapNotNull<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing only the non-null results of
   /// applying the given [transform] function to each element in the original
   /// collection.
@@ -628,7 +734,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableMapIndexed<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing the results of applying the
   /// given [transform] function to each element and its index in the original
   /// collection.
@@ -638,7 +746,9 @@ extension IterableX<E> on Iterable<E> {
       yield transform(index++, element);
     }
   }
+}
 
+extension IterableMapIndexedNotNull<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing only the non-null results of
   /// applying the given [transform] function to each element and its index
   /// in the original collection.
@@ -651,7 +761,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableOnEach<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] which performs the given action on each
   /// element.
   Iterable<E> onEach(void Function(E element) action) sync* {
@@ -660,7 +772,9 @@ extension IterableX<E> on Iterable<E> {
       yield element;
     }
   }
+}
 
+extension IterableDistinct<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing only distinct elements from the
   /// collection.
   ///
@@ -674,7 +788,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableDistinctBy<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing only elements from the collection
   /// having distinct keys returned by the given [selector] function.
   ///
@@ -688,7 +804,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableChunked<E> on Iterable<E> {
   /// Splits this collection into a new lazy [Iterable] of lists each not
   /// exceeding the given [size].
   ///
@@ -714,7 +832,9 @@ extension IterableX<E> on Iterable<E> {
       yield currentChunk;
     }
   }
+}
 
+extension IterableChunkWhile<E> on Iterable<E> {
   /// Splits this collection into a lazy [Iterable] of chunks, where chunks are
   /// created as long as [predicate] is true for a pair of entries.
   ///
@@ -750,7 +870,9 @@ extension IterableX<E> on Iterable<E> {
 
     if (currentChunk.isNotEmpty) yield currentChunk;
   }
+}
 
+extension IterableSplitWhen<E> on Iterable<E> {
   /// Splits this collection into a lazy [Iterable], where each split will be
   /// make if [predicate] returns true for a pair of entries.
   ///
@@ -768,7 +890,9 @@ extension IterableX<E> on Iterable<E> {
   Iterable<List<E>> splitWhen(bool Function(E, E) predicate) {
     return chunkWhile((a, b) => !predicate(a, b));
   }
+}
 
+extension IterableWindowed<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] of windows of the given [size] sliding along
   /// this collection with the given [step].
   ///
@@ -824,7 +948,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableFlatMap<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] of all elements yielded from results of
   /// [transform] function being invoked on each element of this collection.
   Iterable<R> flatMap<R>(Iterable<R> Function(E element) transform) sync* {
@@ -832,7 +958,9 @@ extension IterableX<E> on Iterable<E> {
       yield* transform(current);
     }
   }
+}
 
+extension IterableCycle<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] which iterates over this collection [n]
   /// times.
   ///
@@ -847,6 +975,7 @@ extension IterableX<E> on Iterable<E> {
     }
     if (n == null) {
       yield it.current;
+      // ignore: literal_only_boolean_expressions
       while (true) {
         while (it.moveNext()) {
           yield it.current;
@@ -864,9 +993,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
-  // Operations with other iterables
-
+extension IterableIntersect<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements that are contained
   /// by both this collection and the [other] collection.
   ///
@@ -883,7 +1012,9 @@ extension IterableX<E> on Iterable<E> {
       }
     }
   }
+}
 
+extension IterableExcept<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements of this collection
   /// except the elements contained in the given [elements] collection.
   Iterable<E> except(Iterable<E> elements) sync* {
@@ -891,11 +1022,15 @@ extension IterableX<E> on Iterable<E> {
       if (!elements.contains(current)) yield current;
     }
   }
+}
 
+extension IterableMinus<E> on Iterable<E> {
   /// Returns a new list containing all elements of this collection except the
   /// elements contained in the given [elements] collection.
   List<E> operator -(Iterable<E> elements) => except(elements).toList();
+}
 
+extension IterableExceptElement<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements of this collection
   /// except the given [element].
   Iterable<E> exceptElement(E element) sync* {
@@ -903,39 +1038,51 @@ extension IterableX<E> on Iterable<E> {
       if (element != current) yield current;
     }
   }
+}
 
+extension IterablePrepend<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements of this collection
   /// and then all elements of the given [elements] collection.
   Iterable<E> prepend(Iterable<E> elements) sync* {
     yield* elements;
     yield* this;
   }
+}
 
+extension IterablePrependElement<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements of this collection
   /// and then the given [element].
   Iterable<E> prependElement(E element) sync* {
     yield element;
     yield* this;
   }
+}
 
+extension IterableAppend<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all elements of the given
   /// [elements] collection and then all elements of this collection.
   Iterable<E> append(Iterable<E> elements) sync* {
     yield* this;
     yield* elements;
   }
+}
 
+extension IterablePlus<E> on Iterable<E> {
   /// Returns a new list containing all elements of the given [elements]
   /// collection and then all elements of this collection.
   List<E> operator +(Iterable<E> elements) => append(elements).toList();
+}
 
+extension IterableAppendElement<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing the given [element] and then all
   /// elements of this collection.
   Iterable<E> appendElement(E element) sync* {
     yield* this;
     yield element;
   }
+}
 
+extension IterableUnion<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] containing all distinct elements from
   /// both collections.
   ///
@@ -952,7 +1099,9 @@ extension IterableX<E> on Iterable<E> {
       if (existing.add(element)) yield element;
     }
   }
+}
 
+extension IterableZip<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] of values built from the elements of this
   /// collection and the [other] collection with the same index.
   ///
@@ -979,28 +1128,38 @@ extension IterableX<E> on Iterable<E> {
       yield transform(it1.current, it2.current);
     }
   }
+}
 
-  ///Tranformations to other structures
-
+extension IterableToIterable<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] with all elements of this collection.
   Iterable<E> toIterable() sync* {
     yield* this;
   }
+}
 
+extension IterableAsStream<E> on Iterable<E> {
   /// Returns a new [Stream] with all elements of this collection.
   Stream<E> asStream() => Stream.fromIterable(this);
+}
 
+extension IterableToHashSet<E> on Iterable<E> {
   /// Returns a new [HashSet] with all distinct elements of this collection.
   HashSet<E> toHashSet() => HashSet.from(this);
+}
 
+extension IterableToUnmodifiable<E> on Iterable<E> {
   /// Returns an unmodifiable List view of this collection.
-  List<E> toUnmodifiable() => UnmodifiableListView(this);
+  List<E> toUnmodifiable() => collection.UnmodifiableListView(this);
+}
 
+extension IterableShuffled<E> on Iterable<E> {
   /// Returns a new, randomly shuffled list.
   ///
   /// If [random] is given, it is being used for random number generation.
   List<E> shuffled([Random? random]) => toList()..shuffle(random);
+}
 
+extension IterableAssociate<E> on Iterable<E> {
   /// Returns a Map containing key-value pairs provided by [transform] function
   /// applied to elements of this collection.
   ///
@@ -1014,7 +1173,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return map;
   }
+}
 
+extension IterableAssociateBy<E> on Iterable<E> {
   /// Returns a Map containing the elements from the collection indexed by
   /// the key returned from [keySelector] function applied to each element.
   ///
@@ -1027,7 +1188,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return map;
   }
+}
 
+extension IterableAssociateWith<E> on Iterable<E> {
   /// Returns a Map containing the values returned from [valueSelector] function
   /// applied to each element indexed by the elements from the collection.
   ///
@@ -1040,7 +1203,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return map;
   }
+}
 
+extension IterableGroupBy<E> on Iterable<E> {
   /// Groups elements of the original collection by the key returned by the
   /// given [keySelector] function applied to each element and returns a map.
   ///
@@ -1049,9 +1214,11 @@ extension IterableX<E> on Iterable<E> {
   /// The returned map preserves the entry iteration order of the keys produced
   /// from the original collection.
   Map<K, List<E>> groupBy<K>(K Function(E element) keySelector) {
-    return _groupBy(this, keySelector);
+    return collection.groupBy(this, keySelector);
   }
+}
 
+extension IterablePartition<E> on Iterable<E> {
   /// Splits the collection into two lists according to [predicate].
   ///
   /// The first list contains elements for which [predicate] yielded true,
@@ -1069,7 +1236,9 @@ extension IterableX<E> on Iterable<E> {
     }
     return [t, f];
   }
+}
 
+extension IterableCached<E> on Iterable<E> {
   /// Returns a new lazy [Iterable] that caches the computation of the current
   /// [Iterable].
   ///

--- a/lib/src/iterable_num.dart
+++ b/lib/src/iterable_num.dart
@@ -1,7 +1,7 @@
 part of dartx;
 
 /// Extensions for iterables
-extension IterableNumX<T extends num> on Iterable<T> {
+extension IterableNumSumExtension<T extends num> on Iterable<T> {
   /// Returns the sum of all elements in the collection.
   T sum() {
     num sum = 0.0;
@@ -14,7 +14,9 @@ extension IterableNumX<T extends num> on Iterable<T> {
       return sum.toDouble() as T;
     }
   }
+}
 
+extension IterableNumAverageExtension<T extends num> on Iterable<T> {
   /// Returns the average of all elements in the collection.
   double average() {
     var count = 0;
@@ -30,7 +32,9 @@ extension IterableNumX<T extends num> on Iterable<T> {
       return sum / count;
     }
   }
+}
 
+extension IterableNumMedianExtension<T extends num> on Iterable<T> {
   /// Returns the median of the elements in this collection.
   ///
   /// Empty collections throw an error.

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -2,11 +2,6 @@
 
 part of dartx;
 
-const _binarySearch = binarySearch;
-const _lowerBound = lowerBound;
-const _insertionSort = insertionSort;
-const _mergeSort = mergeSort;
-
 extension ListX<E> on List<E> {
   /// Index of the first element or -1 if the collection is empty.
   ///
@@ -99,7 +94,7 @@ extension ListX<E> on List<E> {
   ///
   /// Returns [length] if all the items in this list compare less than [value].
   int lowerBound(E value, {int Function(E a, E b)? compare}) {
-    return _lowerBound(this, value, compare: compare);
+    return collection.lowerBound(this, value, compare: compare);
   }
 
   /// Returns a position of the [value] in this list, if it is there.
@@ -113,7 +108,7 @@ extension ListX<E> on List<E> {
   ///
   /// Returns -1 if [value] is not in the list by default.
   int binarySearch(E value, {int Function(E a, E b)? compare}) {
-    return _binarySearch(this, value, compare: compare);
+    return collection.binarySearch(this, value, compare: compare);
   }
 
   /// Sort this list between [start] (inclusive) and [end] (exclusive) using
@@ -133,7 +128,7 @@ extension ListX<E> on List<E> {
   /// This insertion sort is stable: Equal elements end up in the same order
   /// as they started in.
   void insertionSort({Comparator<E>? comparator, int start = 0, int? end}) {
-    _insertionSort(this, compare: comparator, start: start, end: end);
+    collection.insertionSort(this, compare: comparator, start: start, end: end);
   }
 
   /// Sorts this list between [start] (inclusive) and [end] (exclusive) using
@@ -153,7 +148,7 @@ extension ListX<E> on List<E> {
   /// This merge sort is stable: Equal elements end up in the same order
   /// as they started in.
   void mergeSort({int start = 0, int? end, Comparator<E>? comparator}) {
-    _mergeSort(this, start: start, end: end, compare: comparator);
+    collection.mergeSort(this, start: start, end: end, compare: comparator);
   }
 
   /// Swaps the elements in the indices provided.

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -2,7 +2,7 @@
 
 part of dartx;
 
-extension ListX<E> on List<E> {
+extension ListExtension<E> on List<E> {
   /// Index of the first element or -1 if the collection is empty.
   ///
   /// ```dart
@@ -11,7 +11,9 @@ extension ListX<E> on List<E> {
   /// [].firstIndex; // -1
   /// ```
   int get firstIndex => isNotEmpty ? 0 : -1;
+}
 
+extension ListLastIndexExtension<E> on List<E> {
   /// Index of the last element or -1 if the collection is empty.
   ///
   /// ```dart
@@ -20,14 +22,18 @@ extension ListX<E> on List<E> {
   /// [].lastIndex; // -1
   /// ```
   int get lastIndex => length - 1;
+}
 
+extension ListIndicesExtension<E> on List<E> {
   Iterable<int> get indices sync* {
     var index = 0;
     while (index <= lastIndex) {
       yield index++;
     }
   }
+}
 
+extension ListDropExtension<E> on List<E> {
   /// Returns a new list containing all elements except first [n] elements.
   List<E> drop(int n) {
     if (n < 0) {
@@ -40,7 +46,9 @@ extension ListX<E> on List<E> {
     if (resultSize == 1) return [last!];
     return sublist(n);
   }
+}
 
+extension ListDropWhileExtension<E> on List<E> {
   /// Returns a new list containing all elements except last elements that
   /// satisfy the given [predicate].
   List<E> dropWhile(bool Function(E element) predicate) {
@@ -54,7 +62,9 @@ extension ListX<E> on List<E> {
     if (startIndex == null) return [];
     return sublist(startIndex);
   }
+}
 
+extension ListDropLastExtension<E> on List<E> {
   /// Returns a new list containing all elements except last [n] elements.
   List<E> dropLast(int n) {
     if (n < 0) {
@@ -67,7 +77,9 @@ extension ListX<E> on List<E> {
     if (resultSize == 1) return [first];
     return sublist(0, length - n);
   }
+}
 
+extension ListDropLastWhileExtension<E> on List<E> {
   /// Returns a new list containing all elements except last elements that
   /// satisfy the given [predicate].
   List<E> dropLastWhile(bool Function(E element) predicate) {
@@ -81,7 +93,9 @@ extension ListX<E> on List<E> {
     if (endIndex == null) return [];
     return sublist(0, endIndex + 1);
   }
+}
 
+extension ListLowerBoundExtension<E> on List<E> {
   /// Returns the first position in this list that does not compare less than
   /// [value].
   ///
@@ -96,7 +110,9 @@ extension ListX<E> on List<E> {
   int lowerBound(E value, {int Function(E a, E b)? compare}) {
     return collection.lowerBound(this, value, compare: compare);
   }
+}
 
+extension ListBinarySearchExtension<E> on List<E> {
   /// Returns a position of the [value] in this list, if it is there.
   ///
   /// If the list isn't sorted according to the [compare] function, the result
@@ -110,7 +126,9 @@ extension ListX<E> on List<E> {
   int binarySearch(E value, {int Function(E a, E b)? compare}) {
     return collection.binarySearch(this, value, compare: compare);
   }
+}
 
+extension ListInsertionSortExtension<E> on List<E> {
   /// Sort this list between [start] (inclusive) and [end] (exclusive) using
   /// insertion sort.
   ///
@@ -130,7 +148,9 @@ extension ListX<E> on List<E> {
   void insertionSort({Comparator<E>? comparator, int start = 0, int? end}) {
     collection.insertionSort(this, compare: comparator, start: start, end: end);
   }
+}
 
+extension ListMergeSortExtension<E> on List<E> {
   /// Sorts this list between [start] (inclusive) and [end] (exclusive) using
   /// the merge sort algorithm.
   ///
@@ -150,7 +170,9 @@ extension ListX<E> on List<E> {
   void mergeSort({int start = 0, int? end, Comparator<E>? comparator}) {
     collection.mergeSort(this, start: start, end: end, compare: comparator);
   }
+}
 
+extension ListSwapExtension<E> on List<E> {
   /// Swaps the elements in the indices provided.
   ///
   /// ```dart
@@ -164,7 +186,7 @@ extension ListX<E> on List<E> {
   }
 }
 
-extension ListListX<E> on List<List<E>> {
+extension ListFlattenExtension<E> on List<List<E>> {
   /// Returns a new [List] of all elements from all lists in this
   /// [List].
   ///

--- a/lib/src/num.dart
+++ b/lib/src/num.dart
@@ -1,6 +1,6 @@
 part of dartx;
 
-extension NumX<T extends num> on T {
+extension NumCoerceInExtension<T extends num> on T {
   /// Ensures that this value lies in the specified range
   /// [minimumValue]..[maximumValue].
   ///
@@ -23,7 +23,9 @@ extension NumX<T extends num> on T {
     if (maximumValue != null && this > maximumValue) return maximumValue;
     return this;
   }
+}
 
+extension NumCoerceAtLeastExtension<T extends num> on T {
   /// Ensures that this value is not less than the specified [minimumValue].
   ///
   /// Return this value if it's greater than or equal to the [minimumValue]
@@ -34,7 +36,9 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtLeast(20)) // 20
   /// ```
   T coerceAtLeast(T minimumValue) => this < minimumValue ? minimumValue : this;
+}
 
+extension NumCoerceAtMostExtension<T extends num> on T {
   /// Ensures that this value is not greater than the specified [maximumValue].
   ///
   /// Return this value if it's less than or equal to the [maximumValue] or the
@@ -45,10 +49,14 @@ extension NumX<T extends num> on T {
   /// print(10.coerceAtMost(20)) // 10
   /// ```
   T coerceAtMost(T maximumValue) => this > maximumValue ? maximumValue : this;
+}
 
+extension NumCoerceInRangeExtension<T extends num> on T {
   /// Returns true if in the [range].
   bool inRange(Range<num> range) => range.contains(this);
+}
 
+extension NumBetweenExtension<T extends num> on T {
   /// Returns true if between [first] and [endInclusive].
   ///
   /// Alias for `first.rangeTo(endInclusive).contains(this)`
@@ -56,7 +64,7 @@ extension NumX<T extends num> on T {
       first.rangeTo(endInclusive).contains(this);
 }
 
-extension IntX<T extends int> on T {
+extension IntToBytesExtension<T extends int> on T {
   /// Converts this value to binary form.
   Uint8List toBytes([Endian endian = Endian.big]) {
     final data = ByteData(8);
@@ -65,7 +73,7 @@ extension IntX<T extends int> on T {
   }
 }
 
-extension DoubleX<T extends double> on T {
+extension DoubleToBytesExtension<T extends double> on T {
   /// Converts this value to binary form.
   Uint8List toBytes([Endian endian = Endian.big]) {
     final data = ByteData(8);

--- a/lib/src/range.dart
+++ b/lib/src/range.dart
@@ -66,7 +66,7 @@ extension ComparableRangeX<T extends Comparable<T>> on T {
 }
 
 /// The equivalent for [double] is [DoubleRangeExtension]
-extension IntRangeExtension on int {
+extension IntRangeToExtension on int {
   /// Creates a [IntRange] with a step count of 1
   ///
   /// ```
@@ -94,7 +94,7 @@ extension IntRangeExtension on int {
 /// therefore doesn't work for the `Comparable<T>.rangeTo(T)` extension
 ///
 /// The equivalent for [int] is [IntRangeExtension]
-extension DoubleRangeExtension on double {
+extension DoubleRangeToExtension on double {
   DoubleRange rangeTo(double endInclusive) => DoubleRange(this, endInclusive);
 }
 

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -3,7 +3,7 @@ part of dartx;
 const _ascii = 0x007f;
 const _latin1 = 0x00ff;
 
-extension StringX on String {
+extension StringCharsExtension on String {
   /// The characters of a string.
   ///
   /// A character is a Unicode Grapheme cluster represented by a substring of
@@ -13,7 +13,9 @@ extension StringX on String {
   /// https://github.com/dart-lang/characters/blob/10527437926f1b454edf9912fe700aa2506b1c3d/lib/src/extensions.dart#L9
   @Deprecated('Use .characters from the official characters package')
   Iterable<String> get chars => characters.Characters(this);
+}
 
+extension StringCapitalizeExtension on String {
   /// Returns a copy of this string having its first letter uppercased, or the
   /// original string, if it's empty or already starts with an upper case
   /// letter.
@@ -32,7 +34,9 @@ extension StringX on String {
         return substring(0, 1).toUpperCase() + substring(1);
     }
   }
+}
 
+extension StringDecapitalizeExtension on String {
   /// Returns a copy of this string having its first letter lowercased, or the
   /// original string, if it's empty or already starts with a lower case letter.
   ///
@@ -50,41 +54,59 @@ extension StringX on String {
         return substring(0, 1).toLowerCase() + substring(1);
     }
   }
+}
 
+extension StringIsBlankExtension on String {
   /// Returns `true` if this string is empty or consists solely of whitespace
   /// characters.
   bool get isBlank => trimLeft().isEmpty;
+}
 
+extension StringIsNotBlankExtension on String {
   /// Returns `true` if this char sequence is not empty and contains some
   /// characters except of whitespace characters.
   bool get isNotBlank => !isBlank;
+}
 
+extension StringIsUpperCaseExtension on String {
   /// Returns `true` if the whole string is upper case.
   bool get isUpperCase => isNotEmpty && this == toUpperCase();
+}
 
+extension StringIsLowerCaseExtension on String {
   /// Returns `true` if the whole string is lower case.
   bool get isLowerCase => isNotEmpty && this == toLowerCase();
+}
 
+extension StringIsCapitalizedExtension on String {
   /// Returns `true` if the first character is upper case.
   bool get isCapitalized => isNotEmpty && this[0].isUpperCase;
+}
 
+extension StringIsDecapitalizedExtension on String {
   /// Returns `true` if the first character is lower case.
   bool get isDecapitalized => isNotEmpty && this[0].isLowerCase;
+}
 
+extension StringIsAsciiExtension on String {
   bool get isAscii {
     for (final codeUnit in codeUnits) {
       if (codeUnit > _ascii) return false;
     }
     return true;
   }
+}
 
+extension StringIsLatin1Extension on String {
   bool get isLatin1 {
     for (final codeUnit in codeUnits) {
       if (codeUnit > _latin1) return false;
     }
     return true;
   }
+}
 
+extension StringReversedExtension on String {
   /// Returns a new string with characters in reversed order.
   String get reversed {
     final range = characters.Characters(this).iteratorAtEnd;
@@ -96,9 +118,13 @@ extension StringX on String {
 
     return buffer.toString();
   }
+}
 
+extension StringIsIntExtension on String {
   bool get isInt => toIntOrNull() != null;
+}
 
+extension StringToIntExtension on String {
   /// Parses the string as an [int] number and returns the result.
   ///
   /// The [radix] must be in the range 2..36. The digits used are
@@ -108,7 +134,9 @@ extension StringX on String {
   ///
   /// If no [radix] is given then it defaults to 10.
   int toInt({int? radix}) => int.parse(this, radix: radix);
+}
 
+extension StringToIntOrNullExtension on String {
   /// Parses the string as an [int] number and returns the result or `null` if
   /// the string is not a valid representation of a number.
   ///
@@ -119,20 +147,32 @@ extension StringX on String {
   ///
   /// If no [radix] is given then it defaults to 10.
   int? toIntOrNull({int? radix}) => int.tryParse(this, radix: radix);
+}
 
+extension StringIsDoubleExtension on String {
   bool get isDouble => toDoubleOrNull() != null;
+}
 
+extension StringToDoubleExtension on String {
   /// Parses the string as a [double] number and returns the result.
   double toDouble() => double.parse(this);
+}
 
+extension StringToDoubleOrNullExtension on String {
   /// Parses the string as an [double] number and returns the result or `null`
   /// if the string is not a valid representation of a number.
   double? toDoubleOrNull() => double.tryParse(this);
+}
 
+extension StringToUtf8Extension on String {
   List<int> toUtf8() => utf8.encode(this);
+}
 
+extension StringToUtf16Extension on String {
   List<int> toUtf16() => codeUnits;
+}
 
+extension StringMd5Extension on String {
   /// Calculates the MD5 digest and returns the value as a [String] of
   /// hexadecimal digits.
   ///
@@ -141,7 +181,9 @@ extension StringX on String {
   /// print('message digest'.md5); //f96b697d7cb7938d525a2f31aaf161d0
   /// ```
   String get md5 => crypto.md5.convert(toUtf8()).toString();
+}
 
+extension StringRemovePrefixExtension on String {
   /// If this [String] starts with the given [prefix], returns a copy of this
   /// string with the prefix removed. Otherwise, returns this [String].
   String removePrefix(String prefix) {
@@ -151,7 +193,9 @@ extension StringX on String {
       return this;
     }
   }
+}
 
+extension StringRemoveSuffixExtension on String {
   /// If this [String] ends with the given [suffix], returns a copy of this
   /// [String] with the suffix removed. Otherwise, returns this [String].
   String removeSuffix(String suffix) {
@@ -161,7 +205,9 @@ extension StringX on String {
       return this;
     }
   }
+}
 
+extension StringRemoveSurroundingExtension on String {
   /// Removes from a [String] both the given [prefix] and [suffix] if and only
   /// if it starts with the [prefix] and ends with the [suffix].
   /// Otherwise returns this [String] unchanged.
@@ -172,7 +218,9 @@ extension StringX on String {
       return this;
     }
   }
+}
 
+extension StringSliceExtension on String {
   /// Returns a new substring containing all characters between [start]
   /// (inclusive) and [end] (inclusive).
   /// If [end] is omitted, it is being set to `lastIndex`.
@@ -191,9 +239,11 @@ extension StringX on String {
   }
 }
 
-extension StringXN on String? {
+extension NullableStringIsNullOrEmptyExtension on String? {
   /// Returns `true` if the String is either null or empty.
   bool get isNullOrEmpty => this?.isEmpty ?? true;
+}
 
+extension NullableStringIsNotNullOrEmptyExtension on String? {
   bool get isNotNullOrEmpty => !isNullOrEmpty;
 }

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -12,7 +12,7 @@ extension StringX on String {
   /// Please use [StringCharacters].characters
   /// https://github.com/dart-lang/characters/blob/10527437926f1b454edf9912fe700aa2506b1c3d/lib/src/extensions.dart#L9
   @Deprecated('Use .characters from the official characters package')
-  Iterable<String> get chars => Characters(this);
+  Iterable<String> get chars => characters.Characters(this);
 
   /// Returns a copy of this string having its first letter uppercased, or the
   /// original string, if it's empty or already starts with an upper case
@@ -87,7 +87,7 @@ extension StringX on String {
 
   /// Returns a new string with characters in reversed order.
   String get reversed {
-    final range = Characters(this).iteratorAtEnd;
+    final range = characters.Characters(this).iteratorAtEnd;
 
     final buffer = StringBuffer();
     while (range.moveBack()) {


### PR DESCRIPTION
Fixes compatibility issues with `package:collection` because now `dartx` extensions can be hidden or shown on the import with `hide`/`show`.

I create the same PR for `package:collection` https://github.com/dart-lang/collection/pull/184