### PR TITLE
whereNotNull should transform generic type to non-nullable.

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -623,9 +623,9 @@ extension IterableFilterNotToIndexed<E> on Iterable<E> {
       whereNotToIndexed(destination, predicate);
 }
 
-extension IterableFilterNotNull<E> on Iterable<E> {
+extension IterableFilterNotNull<E> on Iterable<E?> {
   /// Returns a new lazy [Iterable] with all elements which are not null.
-  Iterable<E> filterNotNull() => where((element) => element != null);
+  Iterable<E> filterNotNull() => whereNotNull();
 }
 
 extension IterableWhereIndexed<E> on Iterable<E> {
@@ -717,9 +717,9 @@ extension IterableWhereNotToIndexed<E> on Iterable<E> {
   }
 }
 
-extension IterableWhereNotNull<E> on Iterable<E> {
+extension IterableWhereNotNull<E> on Iterable<E?> {
   /// Returns a new lazy [Iterable] with all elements which are not null.
-  Iterable<E> whereNotNull() => where((element) => element != null);
+  Iterable<E> whereNotNull() => where((element) => element != null).cast<E>();
 }
 
 extension IterableMapNotNull<E> on Iterable<E> {

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -475,6 +475,10 @@ void main() {
       expect([0, null, 1, null, null, 2].whereNotNull(), [0, 1, 2]);
     });
 
+    test('.whereNotNull()', () {
+      expect([0, null, 1, null, 2].whereNotNull().map((e) => e + 1), [1, 2, 3]);
+    });
+
     test('.mapNotNull()', () {
       expect([].mapNotNull((it) => 1), []);
       expect([1, 2, 3, 4].mapNotNull((it) => null), []);


### PR DESCRIPTION
`whereNotNull()` should transform a Iterable<int?> to an Iterable<int>, I don't think there is a good reason that it's still nullable.