### PR TITLE
Add faster elementAtOrNull implementation for List

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -24,6 +24,22 @@ extension ListLastIndexExtension<E> on List<E> {
   int get lastIndex => length - 1;
 }
 
+extension ListElementAtOrNull<E> on List<E> {
+  /// Returns an element at the given [index] or `null` if the [index] is out of
+  /// bounds of this list.
+  ///
+  /// ```dart
+  /// final list = [1, 2, 3, 4];
+  /// final first = list.elementAtOrNull(0); // 1
+  /// final fifth = list.elementAtOrNull(4); // null
+  /// ```
+  E? elementAtOrNull(int index) {
+    if (index < 0) return null;
+    if (index >= length) return null;
+    return this[index];
+  }
+}
+
 extension ListIndicesExtension<E> on List<E> {
   Iterable<int> get indices sync* {
     var index = 0;

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -41,11 +41,11 @@ void main() {
     });
 
     test('.elementAtOrNull()', () {
-      expect([1, 2, 3].elementAtOrNull(-1), null);
-      expect([1, 2, 3].elementAtOrNull(0), 1);
-      expect([1, 2, 3].elementAtOrNull(1), 2);
-      expect([1, 2, 3].elementAtOrNull(2), 3);
-      expect([1, 2, 3].elementAtOrNull(3), null);
+      expect([1, 2, 3].toIterable().elementAtOrNull(-1), null);
+      expect([1, 2, 3].toIterable().elementAtOrNull(0), 1);
+      expect([1, 2, 3].toIterable().elementAtOrNull(1), 2);
+      expect([1, 2, 3].toIterable().elementAtOrNull(2), 3);
+      expect([1, 2, 3].toIterable().elementAtOrNull(3), null);
     });
 
     test('.elementAtOrDefault()', () {

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -13,6 +13,14 @@ void main() {
       expect([1, 2, 3].lastIndex, 2);
     });
 
+    test('.elementAtOrNull()', () {
+      expect([1, 2, 3].elementAtOrNull(-1), null);
+      expect([1, 2, 3].elementAtOrNull(0), 1);
+      expect([1, 2, 3].elementAtOrNull(1), 2);
+      expect([1, 2, 3].elementAtOrNull(2), 3);
+      expect([1, 2, 3].elementAtOrNull(3), null);
+    });
+
     test('.indices', () {
       expect([].indices, []);
       expect([1, 2, 3].indices, [0, 1, 2]);


### PR DESCRIPTION
While `Iterable` doesn't have necessarily a length (might be infinite), a list has a fixed size and a faster lookup is possible

Fixes #124 