### PR TITLE
#110 add `Iterable<E>.startsWith(Iterable<E>)` and test

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1334,3 +1334,32 @@ extension IterableFutureX<E> on Iterable<Future<E>> {
   /// When all futures have completed, the stream is closed.
   Stream<E> asStreamAwaited() => Stream.fromFutures(this);
 }
+
+extension IterableStartsWithExtension<E> on Iterable<E> {
+  /// Returns if this [Iterable] starts with the elements of [otherIterable].
+  ///
+  /// If [otherIterable] is empty, `true` is returned. If [otherIterable] has
+  /// more elements than this [Iterable], `false` is returned.
+  ///
+  /// ```dart
+  /// [1, 2, 3].startsWith([]); // -> true
+  /// [1, 2, 3].startsWith([1]); // -> true
+  /// [1, 2, 3].startsWith([1, 2]); // -> true
+  /// [1, 2, 3].startsWith([1, 2, 3]); // -> true
+  /// [1, 2, 3].startsWith([1, 2, 3, 4]); // -> false
+  /// [1, 2, 3].startsWith([2, 3]); // -> false
+  /// ```
+  bool startsWith(Iterable<E> otherIterable) {
+    final thisIterator = iterator;
+    final otherIterator = otherIterable.iterator;
+    if (!otherIterator.moveNext()) return true;
+    do {
+      // this iterator is empty or the current elements are different
+      if (!thisIterator.moveNext() ||
+          otherIterator.current != thisIterator.current) {
+        return false;
+      }
+    } while (otherIterator.moveNext());
+    return true;
+  }
+}

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -951,5 +951,17 @@ void main() {
         expect(accessCount, 3);
       });
     });
+
+    test('.startsWith()', () {
+      expect([].startsWith([]), true);
+      expect([1, 2, 3].startsWith([]), true);
+      expect([1, 2, 3].startsWith([1]), true);
+      expect([1, 2, 3].startsWith([1, 2]), true);
+      expect([1, 2, 3].startsWith([1, 2, 3]), true);
+      expect([1, 2, 3].startsWith([1, 2, 3, 4]), false);
+      expect([1, 2, 3].startsWith([2, 3, 4]), false);
+      expect([1, 2, 3].startsWith([2, 3]), false);
+      expect([1, 2, 3].startsWith([2]), false);
+    });
   });
 }

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -962,6 +962,9 @@ void main() {
       expect([1, 2, 3].startsWith([2, 3, 4]), false);
       expect([1, 2, 3].startsWith([2, 3]), false);
       expect([1, 2, 3].startsWith([2]), false);
+      expect([].startsWith([1, 2, 3]), false);
+      expect([null, 1, 2, 3].startsWith([null, 1]), true);
+      expect([1, null, 3].startsWith([1, null]), true);
     });
   });
 }


### PR DESCRIPTION
Added the method `Iterable<E>.startsWith(Iterable<E>)`. This was requested by #110.