### PR TITLE
Remove redundant logic

### DIFF
--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -77,8 +77,7 @@ extension StringIsUpperCaseExtension on String {
   /// '!'.isUpperCase // false
   /// 'HEY, YOU!'.isUpperCase // true
   /// ```
-  bool get isUpperCase =>
-      isNotEmpty && this == toUpperCase() && this != toLowerCase();
+  bool get isUpperCase => this == toUpperCase() && this != toLowerCase();
 }
 
 extension StringIsLowerCaseExtension on String {
@@ -90,8 +89,7 @@ extension StringIsLowerCaseExtension on String {
   /// '!'.isLowerCase // false
   /// 'hey, you!'.isLowerCase // true
   /// ```
-  bool get isLowerCase =>
-      isNotEmpty && this == toLowerCase() && this != toUpperCase();
+  bool get isLowerCase => this == toLowerCase() && this != toUpperCase();
 }
 
 extension StringIsCapitalizedExtension on String {

--- a/test/arithmetic_test.dart
+++ b/test/arithmetic_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:dartx/dartx.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('num', () {


### PR DESCRIPTION
In the course of https://github.com/leisim/dartx/pull/142, it was forgotten that some logic became redundant and can be removed. This is being done retroactively. @passsy 