### PR TITLE
Lint update (early 22)

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -277,8 +277,8 @@ extension IterableSortedBy<E> on Iterable<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> sortedBy(Comparable Function(E element) selector) {
-    return _SortedList<E>._withSelector(this, selector, 1, null);
+  SortedList<E> sortedBy(Comparable Function(E element) selector) {
+    return SortedList<E>._withSelector(this, selector, 1, null);
   }
 }
 
@@ -292,8 +292,8 @@ extension IterableSortedByDescending<E> on Iterable<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> sortedByDescending(Comparable Function(E element) selector) {
-    return _SortedList<E>._withSelector(this, selector, -1, null);
+  SortedList<E> sortedByDescending(Comparable Function(E element) selector) {
+    return SortedList<E>._withSelector(this, selector, -1, null);
   }
 }
 
@@ -306,8 +306,8 @@ extension IterableSortedWith<E> on Iterable<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> sortedWith(Comparator<E> comparator) {
-    return _SortedList<E>._(this, comparator);
+  SortedList<E> sortedWith(Comparator<E> comparator) {
+    return SortedList<E>._(this, comparator);
   }
 }
 

--- a/lib/src/sorted_list.dart
+++ b/lib/src/sorted_list.dart
@@ -12,17 +12,17 @@ Comparator<E> _getComparator<E>(
   return parent?.compose(newComparator) ?? newComparator;
 }
 
-class _SortedList<E> extends _DelegatingList<E> {
+class SortedList<E> extends _DelegatingList<E> {
   final Iterable<E> _source;
   final Comparator<E> _comparator;
   List<E>? _sortedResults;
 
-  _SortedList._(
+  SortedList._(
     this._source,
     this._comparator,
   );
 
-  _SortedList._withSelector(
+  SortedList._withSelector(
     this._source,
     Comparable Function(E element) selector,
     int order,
@@ -44,8 +44,8 @@ class _SortedList<E> extends _DelegatingList<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> thenBy(Comparable Function(E element) selector) {
-    return _SortedList<E>._withSelector(this, selector, 1, _comparator);
+  SortedList<E> thenBy(Comparable Function(E element) selector) {
+    return SortedList<E>._withSelector(this, selector, 1, _comparator);
   }
 
   /// Returns a new list with all elements sorted according to previously
@@ -54,8 +54,8 @@ class _SortedList<E> extends _DelegatingList<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> thenByDescending(Comparable Function(E element) selector) {
-    return _SortedList<E>._withSelector(this, selector, -1, _comparator);
+  SortedList<E> thenByDescending(Comparable Function(E element) selector) {
+    return SortedList<E>._withSelector(this, selector, -1, _comparator);
   }
 
   /// Returns a new list with all elements sorted according to previously
@@ -63,8 +63,8 @@ class _SortedList<E> extends _DelegatingList<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  _SortedList<E> thenWith(Comparator<E> comparator) {
-    return _SortedList<E>._(this, _comparator.compose(comparator));
+  SortedList<E> thenWith(Comparator<E> comparator) {
+    return SortedList<E>._(this, _comparator.compose(comparator));
   }
 
   @override

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -178,7 +178,8 @@ void main() {
 
       expect(list1.contentEquals(list2.toList()), false);
       expect(list1.contentEquals(list2), false);
-      bool compareCodeUnits(e1, e2) => e1.codeUnitAt(0) == e2.codeUnitAt(0);
+      bool compareCodeUnits(String e1, String e2) =>
+          e1.codeUnitAt(0) == e2.codeUnitAt(0);
       expect(list1.contentEquals(list2, compareCodeUnits), true);
       expect(list3.contentEquals(list4), false);
       expect(list4.contentEquals(list3), false);
@@ -370,7 +371,7 @@ void main() {
     });
 
     test('.filterIndexed()', () {
-      final result = [6, 5, 4, 3, 2, 1, 0].filter((it) => it % 2 == 0);
+      final result = [6, 5, 4, 3, 2, 1, 0].filter((it) => it.isEven);
       expect(result, [6, 4, 2, 0]);
     });
 
@@ -387,7 +388,7 @@ void main() {
 
     test('.filterTo()', () {
       final list = <int>[];
-      [1, 2, 3, 4, 3, 2, 1].filterTo(list, (e) => e % 2 == 0);
+      [1, 2, 3, 4, 3, 2, 1].filterTo(list, (e) => e.isEven);
       expect(list, [2, 4, 2]);
     });
 
@@ -396,13 +397,13 @@ void main() {
       final list = <int>[];
       [1, 2, 3, 4, 3, 2, 1].filterIndexedTo(list, (e, i) {
         expect(index++, i);
-        return e % 2 == 0;
+        return e.isEven;
       });
       expect(list, [2, 4, 2]);
     });
 
     test('.filterNot()', () {
-      expect([1, 2, 3, 4, 3, 2, 1].filterNot((e) => e % 2 == 0), [1, 3, 3, 1]);
+      expect([1, 2, 3, 4, 3, 2, 1].filterNot((e) => e.isEven), [1, 3, 3, 1]);
     });
 
     test('.filterNotIndexed()', () {
@@ -410,7 +411,7 @@ void main() {
       expect(
         [1, 2, 3, 4, 3, 2, 1].filterNotIndexed((e, i) {
           expect(index++, i);
-          return e % 2 == 0;
+          return e.isEven;
         }),
         [1, 3, 3, 1],
       );
@@ -418,7 +419,7 @@ void main() {
 
     test('.filterNotTo()', () {
       final list = <int>[];
-      [1, 2, 3, 4, 3, 2, 1].filterNotTo(list, (e) => e % 2 == 0);
+      [1, 2, 3, 4, 3, 2, 1].filterNotTo(list, (e) => e.isEven);
       expect(list, [1, 3, 3, 1]);
     });
 
@@ -427,7 +428,7 @@ void main() {
       final list = <int>[];
       [1, 2, 3, 4, 3, 2, 1].filterNotToIndexed(list, (e, i) {
         expect(index++, i);
-        return e % 2 == 0;
+        return e.isEven;
       });
       expect(list, [1, 3, 3, 1]);
     });
@@ -449,7 +450,7 @@ void main() {
 
     test('.whereTo()', () {
       final list = <int>[];
-      [1, 2, 3, 4, 3, 2, 1].whereTo(list, (e) => e % 2 == 0);
+      [1, 2, 3, 4, 3, 2, 1].whereTo(list, (e) => e.isEven);
       expect(list, [2, 4, 2]);
     });
 
@@ -458,13 +459,13 @@ void main() {
       final list = <int>[];
       [1, 2, 3, 4, 3, 2, 1].whereIndexedTo(list, (e, i) {
         expect(index++, i);
-        return e % 2 == 0;
+        return e.isEven;
       });
       expect(list, [2, 4, 2]);
     });
 
     test('.whereNot()', () {
-      expect([1, 2, 3, 4, 3, 2, 1].whereNot((e) => e % 2 == 0), [1, 3, 3, 1]);
+      expect([1, 2, 3, 4, 3, 2, 1].whereNot((e) => e.isEven), [1, 3, 3, 1]);
     });
 
     test('.whereNotIndexed()', () {
@@ -472,7 +473,7 @@ void main() {
       expect(
         [1, 2, 3, 4, 3, 2, 1].whereNotIndexed((e, i) {
           expect(index++, i);
-          return e % 2 == 0;
+          return e.isEven;
         }),
         [1, 3, 3, 1],
       );
@@ -480,7 +481,7 @@ void main() {
 
     test('.whereNotTo()', () {
       final list = <int>[];
-      [1, 2, 3, 4, 3, 2, 1].whereNotTo(list, (e) => e % 2 == 0);
+      [1, 2, 3, 4, 3, 2, 1].whereNotTo(list, (e) => e.isEven);
       expect(list, [1, 3, 3, 1]);
     });
 
@@ -489,7 +490,7 @@ void main() {
       final list = <int>[];
       [1, 2, 3, 4, 3, 2, 1].whereNotToIndexed(list, (e, i) {
         expect(index++, i);
-        return e % 2 == 0;
+        return e.isEven;
       });
       expect(list, [1, 3, 3, 1]);
     });
@@ -506,7 +507,7 @@ void main() {
       expect([].mapNotNull((it) => 1), []);
       expect([1, 2, 3, 4].mapNotNull((it) => null), []);
       expect(
-        [1, 2, 3, 4].mapNotNull((it) => it % 2 == 0 ? it * 2 : null),
+        [1, 2, 3, 4].mapNotNull((it) => it.isEven ? it * 2 : null),
         [4, 8],
       );
     });
@@ -519,7 +520,7 @@ void main() {
       );
       expect([5, 4, null, 2].mapIndexed((index, it) => index), [0, 1, 2, 3]);
       expect(
-        [1, 2, 3, 4].mapIndexed((index, it) => it % 2 == 0 ? it * 2 : null),
+        [1, 2, 3, 4].mapIndexed((index, it) => it.isEven ? it * 2 : null),
         [null, 4, null, 8],
       );
     });
@@ -533,7 +534,7 @@ void main() {
       );
       expect(
         [1, 2, 3, 4]
-            .mapIndexedNotNull((index, it) => it % 2 == 0 ? it * 2 : null),
+            .mapIndexedNotNull((index, it) => it.isEven ? it * 2 : null),
         [4, 8],
       );
     });
@@ -925,8 +926,7 @@ void main() {
 
     test('groupBy', () {
       expect(
-        ['foo', 'bar', 'baz', 'bop', 'qux']
-            .groupBy((dynamic string) => string[1]),
+        ['foo', 'bar', 'baz', 'bop', 'qux'].groupBy((it) => it[1]),
         equals({
           'o': ['foo', 'bop'],
           'a': ['bar', 'baz'],
@@ -937,7 +937,7 @@ void main() {
 
     test('.partition()', () {
       expect([].partition((it) => false), <List<int>>[[], []]);
-      expect([1, 2, 3, 4, 5, 6].partition((it) => it % 2 == 1), [
+      expect([1, 2, 3, 4, 5, 6].partition((it) => it.isOdd), [
         [1, 3, 5],
         [2, 4, 6]
       ]);

--- a/test/map_test.dart
+++ b/test/map_test.dart
@@ -60,7 +60,7 @@ void main() {
 
       test('count even', () {
         final map = {1: 'a', 2: 'b', 3: 'c'};
-        expect(map.count((it) => it.key % 2 == 0), 1);
+        expect(map.count((it) => it.key.isEven), 1);
       });
     });
 

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -316,7 +316,7 @@ void main() {
       });
       test('lastWhere', () {
         final range = IntProgression(0, 9, step: 3);
-        bool isEven(it) => it % 2 == 0;
+        bool isEven(int it) => it.isEven;
         expect(range.last, 9);
         expect(range.lastWhere(isEven), 6);
       });
@@ -347,7 +347,7 @@ void main() {
       });
       test('firstWhere minds the predicate', () {
         final range = IntProgression(1, 10, step: 3);
-        bool isEven(it) => it % 2 == 0;
+        bool isEven(int it) => it.isEven;
         expect(range.first, 1);
         expect(range.firstWhere(isEven), 4);
       });

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(_sortedList.firstWhere((it) => it.isEven), 2);
     });
     test('fold', () {
-      expect(_sortedList.fold(0, (dynamic a, b) => a + b), 10);
+      expect(_sortedList.fold(0, (int a, b) => a + b), 10);
     });
     test('followedBy', () {
       expect(_sortedList.followedBy([2]), [1, 2, 3, 4, 2]);
@@ -108,7 +108,7 @@ void main() {
       expect(_sortedList.toSet(), {1, 2, 3, 4});
     });
     test('where', () {
-      expect(_sortedList.where((it) => it % 2 == 0), [2, 4]);
+      expect(_sortedList.where((it) => it.isEven), [2, 4]);
     });
     test('whereType', () {
       expect(_sortedList.whereType<int>(), [1, 2, 3, 4]);
@@ -211,7 +211,7 @@ void main() {
     });
     test('removeWhere', () {
       final list = _sortedList;
-      list.removeWhere((it) => it % 2 == 0);
+      list.removeWhere((it) => it.isEven);
       expect(list, [1, 3]);
     });
     test('replaceRange', () {
@@ -221,7 +221,7 @@ void main() {
     });
     test('retainWhere', () {
       final list = _sortedList;
-      list.retainWhere((it) => it % 2 == 0);
+      list.retainWhere((it) => it.isEven);
       expect(list, [2, 4]);
     });
     test('reversed', () {


### PR DESCRIPTION
- Make SortedList a public API. It is exposed so it should be public. (Constructor is private anyways)
- Use isEven/isOdd
