### PR TITLE
Make sure takeFirst and takeLast doesn't crash when n > length

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -520,7 +520,7 @@ extension IterableTakeFirst<E> on Iterable<E> {
   /// ```
   List<E> takeFirst(int n) {
     final list = this is List<E> ? this as List<E> : toList();
-    return list.sublist(0, n);
+    return list.take(n).toList();
   }
 }
 
@@ -536,7 +536,7 @@ extension IterableTakeLast<E> on Iterable<E> {
   /// ```
   List<E> takeLast(int n) {
     final list = this is List<E> ? this as List<E> : toList();
-    return list.sublist(length - n);
+    return list.reversed.take(n).reversed.toList();
   }
 }
 

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -348,12 +348,14 @@ void main() {
       expect([].takeFirst(0), []);
       expect([1, 2, 3].takeFirst(0), []);
       expect([1, 2, 3].takeFirst(2), [1, 2]);
+      expect([1, 2, 3].takeFirst(4), [1, 2, 3]);
     });
 
     test('.takeLast()', () {
       expect([].takeLast(0), []);
       expect([1, 2, 3].takeLast(0), []);
       expect([1, 2, 3].takeLast(2), [2, 3]);
+      expect([1, 2, 3].takeLast(4), [1, 2, 3]);
     });
 
     test('.firstWhile()', () {


### PR DESCRIPTION
This matches the behaviour of Kotlins `takeFirst`/`takeLast`