### PR TITLE
Fix typo in output value in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Chunk entries as long as two elements match a predicate:
 final list = [1, 2, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21];
 final increasingSubSequences = list.chunkWhile((a, b) => a + 1 == b);
 
-// increasingSubSequences = [[1, 2], [4], [9], [10, 11, 12], [15, 16], [19, 20, 21]]
+// increasingSubSequences = [[1, 2], [4], [9, 10, 11, 12], [15, 16], [19, 20, 21]]
 ```
 
 `splitWhen` is the opposite of `chunkWhile` that starts a new chunk every time


### PR DESCRIPTION
I double-checked and it printed `flutter: ([1, 2], [4], [9, 10, 11, 12], [15, 16], [19, 20, 21])`, as expected.