### PR TITLE
Feature: camel, pascal, snake, kebab and dot case styles for string

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,57 @@ Returns a copy of the string having its first letter lowercased, or the original
 final word = 'abcd'.decapitalize(); // abcd
 final anotherWord = 'Abcd'.decapitalize(); // abcd
 ```
-  
+
+### .camel
+
+Returns a copy of this string in camelCase style, or the original string, if it's empty.
+
+```dart
+final a = 'Hello World'.camel(); // helloWorld
+final b = 'helloWorld'.camel(); // helloWorld
+final c = 'long   space'.camel(); // longSpace
+```
+
+### .pascal
+
+Returns a copy of this string in PascalCase style, or the original string, if it's empty.
+
+```dart
+final a = 'Hello World'.pascal(); // HelloWorld
+final b = 'helloWorld'.pascal(); // HelloWorld
+final c = 'long   space'.pascal(); // LongSpace
+```
+
+### .snake
+
+Returns a copy of this string in snake_case style, or the original string, if it's empty.
+
+```dart
+final a = 'Hello World'.snake(); // hello_world
+final b = 'helloWorld'.snake(); // hello_world
+final c = 'long   space'.snake(); // long_space
+```
+
+### .kebab
+
+Returns a copy of this string in kebab-case style, or the original string, if it's empty.
+
+```dart
+final a = 'Hello World'.snake(); // hello-world
+final b = 'helloWorld'.snake(); // hello-world
+final c = 'long   space'.snake(); // long-space
+```
+
+### .dot
+
+Returns a copy of this string in dot.case style, or the original string, if it's empty.
+
+```dart
+final a = 'Hello World'.snake(); // hello.world
+final b = 'helloWorld'.snake(); // hello.world
+final c = 'long   space'.snake(); // long.space
+```
+
 ### .isAscii
 
 Returns `true` if the string is ASCII encoded.

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -44,6 +44,106 @@ extension StringDecapitalizeExtension on String {
   }
 }
 
+extension StringCamelCaseExtension on String {
+  /// Returns a copy of this string in camelCase style, or the original string,
+  /// if it's empty.
+  ///
+  /// ```dart
+  /// print('Hello World'.camel()) // helloWorld
+  /// print('helloWorld'.camel()) // helloWorld
+  /// print('long   space'.camel()) // longSpace
+  /// ```
+  String camel() {
+    if (length > 0) {
+      return pascal().decapitalize();
+    } else {
+      return this;
+    }
+  }
+}
+
+extension StringPascalCaseExtension on String {
+  /// Returns a copy of this string in PascalCase style, or the original string,
+  /// if it's empty.
+  ///
+  /// ```dart
+  /// print('Hello World'.pascal()) // HelloWorld
+  /// print('helloWorld'.pascal()) // HelloWorld
+  /// print('long   space'.pascal()) // LongSpace
+  /// ```
+  String pascal() {
+    switch (length) {
+      case 0:
+        return this;
+      case 1:
+        return toUpperCase();
+      default:
+        return splitMapJoin(
+          RegExp(r'\s+'),
+          onMatch: (m) => '',
+          onNonMatch: (n) => n.capitalize(),
+        );
+    }
+  }
+}
+
+extension StringSnakeCaseExtension on String {
+  /// Returns a copy of this string in snake_case style, or the original string,
+  /// if it's empty.
+  ///
+  /// ```dart
+  /// print('Hello World'.pascal()) // hello_world
+  /// print('helloWorld'.pascal()) // hello_world
+  /// print('long   space'.pascal()) // long_space
+  /// ```
+  String snake() {
+    switch (length) {
+      case 0:
+        return this;
+      case 1:
+        return toLowerCase();
+      default:
+        return splitMapJoin(
+          RegExp('[A-Z]'),
+          onMatch: (m) => ' ${m[0]}'.toLowerCase(),
+          onNonMatch: (n) => n.decapitalize(),
+        ).trim().splitMapJoin(
+              RegExp(r'\s+'),
+              onMatch: (m) => '_',
+              onNonMatch: (n) => n.decapitalize(),
+            );
+    }
+  }
+}
+
+extension StringKebabCaseExtension on String {
+  /// Returns a copy of this string in kebab-case style, or the original string,
+  /// if it's empty.
+  ///
+  /// ```dart
+  /// print('Hello World'.pascal()) // hello-world
+  /// print('helloWorld'.pascal()) // hello-world
+  /// print('long   space'.pascal()) // long-space
+  /// ```
+  String kebab() {
+    return snake().replaceAll('_', '-');
+  }
+}
+
+extension StringDotCaseExtension on String {
+  /// Returns a copy of this string in dot.case style, or the original string,
+  /// if it's empty.
+  ///
+  /// ```dart
+  /// print('Hello World'.dot()) // hello.world
+  /// print('helloWorld'.dot()) // hello.world
+  /// print('long   space'.dot()) // long.space
+  /// ```
+  String dot() {
+    return snake().replaceAll('_', '.');
+  }
+}
+
 extension StringIsBlankExtension on String {
   /// Returns `true` if this string is empty or consists solely of whitespace
   /// characters.

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -21,6 +21,46 @@ void main() {
       expect('test'.decapitalize(), 'test');
     });
 
+    test('.camel()', () {
+      expect(''.camel(), '');
+      expect('Hello World'.camel(), 'helloWorld');
+      expect('helloWorld'.camel(), 'helloWorld');
+      expect('HelloWorld'.camel(), 'helloWorld');
+      expect('long   space'.camel(), 'longSpace');
+    });
+
+    test('.pascal()', () {
+      expect(''.pascal(), '');
+      expect('Hello World'.pascal(), 'HelloWorld');
+      expect('helloWorld'.pascal(), 'HelloWorld');
+      expect('HelloWorld'.pascal(), 'HelloWorld');
+      expect('long   space'.pascal(), 'LongSpace');
+    });
+
+    test('.snake()', () {
+      expect(''.snake(), '');
+      expect('Hello World'.snake(), 'hello_world');
+      expect('helloWorld'.snake(), 'hello_world');
+      expect('HelloWorld'.snake(), 'hello_world');
+      expect('long   space'.snake(), 'long_space');
+    });
+
+    test('.kebab()', () {
+      expect(''.kebab(), '');
+      expect('Hello World'.kebab(), 'hello-world');
+      expect('helloWorld'.kebab(), 'hello-world');
+      expect('HelloWorld'.kebab(), 'hello-world');
+      expect('long   space'.kebab(), 'long-space');
+    });
+
+    test('.dot()', () {
+      expect(''.dot(), '');
+      expect('Hello World'.dot(), 'hello.world');
+      expect('helloWorld'.dot(), 'hello.world');
+      expect('HelloWorld'.dot(), 'hello.world');
+      expect('long   space'.dot(), 'long.space');
+    });
+
     test('.isAscii', () {
       expect('!jI7) ~'.isAscii, true);
       expect('§3'.isAscii, false);


### PR DESCRIPTION
Add new case styles extension for `String`.

- camelCase with `camel()`
- PascalCase with `pascal()`
- snake_case with `snake()`
- kebab-case with `kebab()`
- dot.case with `dot()`

Usage

```dart
'Hello World'.camel(); // helloWorld
'Hello World'.pascal(); // HelloWorld
'Hello World'.snake(); // hello_world
'Hello World'.kebab(); // hello-world
'Hello World'.dot(); // hello.world
```

> See tests for more examples.