### PR TITLE
Add positional `isAscending` to sortedBy

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -281,8 +281,16 @@ extension IterableSortedBy<E> on Iterable<E> {
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  SortedList<E> sortedBy(Comparable Function(E element) selector) {
-    return SortedList<E>.withSelector(this, selector, 1, null);
+  SortedList<E> sortedBy(
+    Comparable Function(E element) selector, [
+    bool isAscending = true,
+  ]) {
+    return SortedList<E>.withSelector(
+      this,
+      selector,
+      isAscending ? 1 : -1,
+      null,
+    );
   }
 }
 

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -276,19 +276,23 @@ extension IterableSortedBy<E> on Iterable<E> {
   /// Returns a new list with all elements sorted according to natural sort
   /// order of the values returned by specified [selector] function.
   ///
+  /// The [ascending] parameter controls the order of sorting:
+  /// - Defaults to `true`, sorting elements in ascending order.
+  /// - Set to `false` to sort elements in descending order.
+  ///
   /// To sort by more than one property, `thenBy()` or `thenByDescending()` can
   /// be called afterwards.
   ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
   SortedList<E> sortedBy(
-    Comparable Function(E element) selector, [
-    bool isAscending = true,
-  ]) {
+    Comparable Function(E element) selector, {
+    bool ascending = true,
+  }) {
     return SortedList<E>.withSelector(
       this,
       selector,
-      isAscending ? 1 : -1,
+      ascending ? 1 : -1,
       null,
     );
   }

--- a/lib/src/sorted_list.dart
+++ b/lib/src/sorted_list.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import 'package:dartx/dartx.dart';
 
 Comparator<E> _getComparator<E>(
@@ -43,10 +44,22 @@ class SortedList<E> extends _DelegatingList<E> {
   /// defined order and natural sort order of the values returned by specified
   /// [selector] function.
   ///
+  /// The [ascending] parameter controls the order of sorting:
+  /// - Defaults to `true`, sorting elements in ascending order.
+  /// - Set to `false` to sort elements in descending order.
+  ///
   /// **Note:** The actual sorting is performed when an element is accessed for
   /// the first time.
-  SortedList<E> thenBy(Comparable Function(E element) selector) {
-    return SortedList<E>.withSelector(this, selector, 1, _comparator);
+  SortedList<E> thenBy(
+    Comparable Function(E element) selector, {
+    bool ascending = true,
+  }) {
+    return SortedList<E>.withSelector(
+      this,
+      selector,
+      ascending ? 1 : -1,
+      _comparator,
+    );
   }
 
   /// Returns a new list with all elements sorted according to previously

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -12,12 +12,9 @@ void main() {
     expect([4, 2, 1, 3].sortedBy((it) => it), [1, 2, 3, 4]);
   });
 
-  test('sort, isAscending', () {
-    var isAscending = true;
-    expect([4, 2, 1, 3].sortedBy((it) => it, isAscending), [1, 2, 3, 4]);
-
-    isAscending = false;
-    expect([4, 2, 1, 3].sortedBy((it) => it, isAscending), [4, 3, 2, 1]);
+  test('sort, ascending', () {
+    expect([4, 2, 1, 3].sortedBy((it) => it, ascending: true), [1, 2, 3, 4]);
+    expect([4, 2, 1, 3].sortedBy((it) => it, ascending: false), [4, 3, 2, 1]);
   });
 
   test('thenBy', () {

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -25,6 +25,16 @@ void main() {
     final thenByDesc = list.thenByDescending((it) => it);
     expect(thenByDesc, ['c', 'ba', 'aa']);
   });
+
+  test('thenBy, ascending', () {
+    final list = ['ba', 'c', 'aa'].sortedBy((it) => it.length);
+    expect(list, ['c', 'ba', 'aa']);
+    final thenBy = list.thenBy((it) => it, ascending: true);
+    expect(thenBy, ['c', 'aa', 'ba']);
+    final thenByDesc = list.thenBy((it) => it, ascending: false);
+    expect(thenByDesc, ['c', 'ba', 'aa']);
+  });
+
   group('_DelegatingIterable', () {
     test('any', () {
       expect(_sortedList.any((it) => it > 2), isTrue);

--- a/test/sorted_list_test.dart
+++ b/test/sorted_list_test.dart
@@ -11,6 +11,15 @@ void main() {
   test('sort', () {
     expect([4, 2, 1, 3].sortedBy((it) => it), [1, 2, 3, 4]);
   });
+
+  test('sort, isAscending', () {
+    var isAscending = true;
+    expect([4, 2, 1, 3].sortedBy((it) => it, isAscending), [1, 2, 3, 4]);
+
+    isAscending = false;
+    expect([4, 2, 1, 3].sortedBy((it) => it, isAscending), [4, 3, 2, 1]);
+  });
+
   test('thenBy', () {
     final list = ['ba', 'c', 'aa'].sortedBy((it) => it.length);
     expect(list, ['c', 'ba', 'aa']);


### PR DESCRIPTION
`sortedBy` is one of the best extensions of `dartx`.

`SortedList` class allows us to sort, and uses the internal `order` int to decide whether it is ascending or not.

This PR simplifies this process so we can simply decide it based on `isAscending` positional boolean in the `sortedBy` extension.

This is useful, because without it, we would have to do additional operations bringing either more boilerplate or additional computations. By adding this positional boolean we can make it straightforward.

- Added tests ✅
- Retrocompatible ✅
- Not a breaking change ✅

