### PR TITLE
fix: Remove firstOrNullWhere

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -104,23 +104,6 @@ extension IterableFirstOrDefault<E> on Iterable<E> {
   E firstOrDefault(E defaultValue) => isNotEmpty ? first : defaultValue;
 }
 
-extension IterableFirstOrNullWhere<E> on Iterable<E> {
-  /// Returns the first element matching the given [predicate], or `null` if no
-  /// such element was found.
-  ///
-  /// ```dart
-  /// final list = ['a', 'Test'];
-  /// final firstLong= list.firstOrNullWhere((e) => e.length > 1); // 'Test'
-  /// final firstVeryLong = list.firstOrNullWhere((e) => e.length > 5); // null
-  /// ```
-  E? firstOrNullWhere(bool Function(E element) predicate) {
-    for (final element in this) {
-      if (predicate(element)) return element;
-    }
-    return null;
-  }
-}
-
 extension IterableLastOrNull<E> on Iterable<E> {
   /// Last element or `null` if the collection is empty.
   ///

--- a/test/iterable_test.dart
+++ b/test/iterable_test.dart
@@ -74,13 +74,6 @@ void main() {
       expect([].firstOrDefault(999), 999);
     });
 
-    test('.firstOrNullWhere()', () {
-      expect([1, 2, 3, 4, 5].firstOrNullWhere((e) => e < 6), 1);
-      expect([1, 2, 3, 4, 5].firstOrNullWhere((e) => e > 3), 4);
-      expect([1, 2, 3, 4, 5].firstOrNullWhere((e) => e > 5), null);
-      expect([].firstOrNullWhere((e) => true), null);
-    });
-
     test('.lastOrNull', () {
       expect([1, 2, 3].lastOrNull, 3);
       expect([].lastOrNull, null);


### PR DESCRIPTION
This pull request removes the `firstOrNullWhere` extension method from the `Iterable` class and its corresponding test cases. The main changes include the removal of the method and the associated tests.

This is because a function with similar functionality exists in the collection package.

### Removal of `firstOrNullWhere` extension method:

* [`lib/src/iterable.dart`](diffhunk://#diff-9863c98a1bd740dc601cb35829bf79f7316e8e8807cbb51fa4be30e706e3969cL107-L123): The `firstOrNullWhere` extension method has been removed. This method was used to find the first element matching a given predicate or return `null` if no such element was found.

### Removal of corresponding test cases:

* [`test/iterable_test.dart`](diffhunk://#diff-2059aa9770dd1093cc2e8fb513cb53fd407d9cd3dde63c4e5b2dbdfd84e840d6L77-L83): The test cases for the `firstOrNullWhere` method have been removed. These tests checked various scenarios to ensure the method worked as expected.